### PR TITLE
developブランチへのマージ時にdev環境向きβ版アプリが配布されるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@
 /captures
 .externalNativeBuild
 .cxx
+
+# Build secrets
+
+app/gradle_secret.properties
+
+# Deployment secrets
+
+app/android-deploy-user.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.firebase.appdistribution'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+
+def keyPropertiesFile = rootProject.file("app/gradle_secret.properties")
+def keyProperties = new Properties()
+keyProperties.load(new FileInputStream(keyPropertiesFile))
 
 android {
     compileSdkVersion 28
@@ -20,9 +25,23 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            firebaseAppDistribution {
+                appId=keyProperties["appDistributionIdDev"]
+                serviceCredentialsFile="$rootDir/app/android-deploy-user.json"
+                testers=keyProperties["appDistributionTestersDev"]
+            }
         }
     }
 
+}
+
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:1.3.1'
+    }
 }
 
 dependencies {

--- a/app/gradle_secret_sample.properties
+++ b/app/gradle_secret_sample.properties
@@ -1,0 +1,2 @@
+appDistributionIdDev=1:12345678901234:android:123456789abcdef0123456
+appDistributionTestersDev=test@mail.no.domein.ntetz.jp

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
 - master
+- develop
 - feature/*
 
 pool:
@@ -8,6 +9,7 @@ pool:
 stages:
 - stage: qa_stage
   displayName: 動作検証ステージ
+  condition: always()
   jobs:
   - job: lint_job
     displayName: lintエラー検出
@@ -34,6 +36,7 @@ stages:
         tasks: 'assembleDebug'
 - stage: beta_app_deploy_stage
   displayName: β版アプリ配布ステージ
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/develop')
   dependsOn: qa_stage
   jobs:
   - job: firebase_deploy_job

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,19 @@ pool:
   vmImage: 'macos-latest'
 
 steps:
+- task: DownloadSecureFile@1
+  displayName: 'App Distribution用のクレデンシャルを取得'
+  name: deployUserCredential
+  inputs:
+    secureFile: nyannyanengine-android-deploy-user.json
+- task: DownloadSecureFile@1
+  displayName: 'ビルド用のクレデンシャルを取得'
+  name: appKeyProperties
+  inputs:
+    secureFile: app_gradle_secret.properties
+- script: |
+    sudo ln -s $(appKeyProperties.secureFilePath) app/gradle_secret.properties
+  displayName: 'ビルド用クレデンシャルをプロジェクト内部に設置'
 - task: Gradle@2
   displayName: '全環境に対してlint'
   inputs:
@@ -29,3 +42,13 @@ steps:
     publishJUnitResults: false
     testResultsFiles: '**/TEST-*.xml'
     tasks: 'assembleDebug'
+- script: |
+    sudo ln -s $(deployUserCredential.secureFilePath) app/android-deploy-user.json
+  displayName: 'App Distribution用クレデンシャルをプロジェクト内部に設置'
+- task: Gradle@2
+  displayName: 'Releaseビルドを配布'
+  inputs:
+    gradleWrapperFile: 'gradlew'
+    gradleOptions: '-Xmx3072m'
+    testResultsFiles: '**/TEST-*.xml'
+    tasks: 'assembleRelease appDistributionUploadRelease'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,45 +10,69 @@ trigger:
 pool:
   vmImage: 'macos-latest'
 
-steps:
-- task: DownloadSecureFile@1
-  displayName: 'App Distribution用のクレデンシャルを取得'
-  name: deployUserCredential
-  inputs:
-    secureFile: nyannyanengine-android-deploy-user.json
-- task: DownloadSecureFile@1
-  displayName: 'ビルド用のクレデンシャルを取得'
-  name: appKeyProperties
-  inputs:
-    secureFile: app_gradle_secret.properties
-- script: |
-    sudo ln -s $(appKeyProperties.secureFilePath) app/gradle_secret.properties
-  displayName: 'ビルド用クレデンシャルをプロジェクト内部に設置'
-- task: Gradle@2
-  displayName: '全環境に対してlint'
-  inputs:
-    workingDirectory: ''
-    gradleWrapperFile: 'gradlew'
-    gradleOptions: '-Xmx3072m'
-    publishJUnitResults: false
-    testResultsFiles: '**/TEST-*.xml'
-    tasks: 'lint'
-- task: Gradle@2
-  displayName: 'Debug環境でビルド'
-  inputs:
-    workingDirectory: ''
-    gradleWrapperFile: 'gradlew'
-    gradleOptions: '-Xmx3072m'
-    publishJUnitResults: false
-    testResultsFiles: '**/TEST-*.xml'
-    tasks: 'assembleDebug'
-- script: |
-    sudo ln -s $(deployUserCredential.secureFilePath) app/android-deploy-user.json
-  displayName: 'App Distribution用クレデンシャルをプロジェクト内部に設置'
-- task: Gradle@2
-  displayName: 'Releaseビルドを配布'
-  inputs:
-    gradleWrapperFile: 'gradlew'
-    gradleOptions: '-Xmx3072m'
-    testResultsFiles: '**/TEST-*.xml'
-    tasks: 'assembleRelease appDistributionUploadRelease'
+stages:
+- stage: qa_stage
+  displayName: 動作検証ステージ
+  jobs:
+  - job: lint_job
+    displayName: lintエラー検出
+    steps:
+    - script: |
+        cp -pi app/gradle_secret_sample.properties app/gradle_secret.properties
+      displayName: 'appモジュールビルド用ダミー設定の設置'
+    - task: Gradle@2
+      displayName: '全環境に対してlint'
+      inputs:
+        workingDirectory: ''
+        gradleWrapperFile: 'gradlew'
+        gradleOptions: '-Xmx3072m'
+        publishJUnitResults: false
+        testResultsFiles: '**/TEST-*.xml'
+        tasks: 'lint'
+  - job: build_job
+    displayName: buildエラー検出
+    pool:
+      vmImage: 'macos-latest'
+    steps:
+    - script: |
+        cp -pi app/gradle_secret_sample.properties app/gradle_secret.properties
+      displayName: 'appモジュールビルド用ダミー設定の設置'
+    - task: Gradle@2
+      displayName: 'Debug環境でビルド'
+      inputs:
+        workingDirectory: ''
+        gradleWrapperFile: 'gradlew'
+        gradleOptions: '-Xmx3072m'
+        publishJUnitResults: false
+        testResultsFiles: '**/TEST-*.xml'
+        tasks: 'assembleDebug'
+- stage: beta_app_deploy_stage
+  displayName: β版アプリ配布ステージ
+  dependsOn: qa_stage
+  jobs:
+  - job: firebase_deploy_job
+    displayName: Firebaseへapk配布
+    steps:
+    - task: DownloadSecureFile@1
+      displayName: 'App Distribution用のクレデンシャルを取得'
+      name: deployUserCredential
+      inputs:
+        secureFile: nyannyanengine-android-deploy-user.json
+    - script: |
+        sudo ln -s $(deployUserCredential.secureFilePath) app/android-deploy-user.json
+      displayName: 'App Distribution用クレデンシャルの参照をプロジェクト内部に設置'
+    - task: DownloadSecureFile@1
+      displayName: 'ビルド用のクレデンシャルを取得'
+      name: appKeyProperties
+      inputs:
+        secureFile: app_gradle_secret.properties
+    - script: |
+        sudo ln -s $(appKeyProperties.secureFilePath) app/gradle_secret.properties
+      displayName: 'ビルド用クレデンシャルの参照をプロジェクト内部に設置'
+    - task: Gradle@2
+      displayName: 'Releaseビルドを配布'
+      inputs:
+        gradleWrapperFile: 'gradlew'
+        gradleOptions: '-Xmx3072m'
+        testResultsFiles: '**/TEST-*.xml'
+        tasks: 'assembleRelease appDistributionUploadRelease'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,3 @@
-# Android
-# Build your Android project with Gradle.
-# Add steps that test, sign, and distribute the APK, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/android
-
 trigger:
 - master
 - feature/*
@@ -23,16 +18,10 @@ stages:
     - task: Gradle@2
       displayName: '全環境に対してlint'
       inputs:
-        workingDirectory: ''
         gradleWrapperFile: 'gradlew'
-        gradleOptions: '-Xmx3072m'
-        publishJUnitResults: false
-        testResultsFiles: '**/TEST-*.xml'
         tasks: 'lint'
   - job: build_job
     displayName: buildエラー検出
-    pool:
-      vmImage: 'macos-latest'
     steps:
     - script: |
         cp -pi app/gradle_secret_sample.properties app/gradle_secret.properties
@@ -40,11 +29,8 @@ stages:
     - task: Gradle@2
       displayName: 'Debug環境でビルド'
       inputs:
-        workingDirectory: ''
         gradleWrapperFile: 'gradlew'
         gradleOptions: '-Xmx3072m'
-        publishJUnitResults: false
-        testResultsFiles: '**/TEST-*.xml'
         tasks: 'assembleDebug'
 - stage: beta_app_deploy_stage
   displayName: β版アプリ配布ステージ
@@ -74,5 +60,4 @@ stages:
       inputs:
         gradleWrapperFile: 'gradlew'
         gradleOptions: '-Xmx3072m'
-        testResultsFiles: '**/TEST-*.xml'
         tasks: 'assembleRelease appDistributionUploadRelease'


### PR DESCRIPTION
`gradle_secret.properties` は、lint、buildの際もβ配布と同様に本物を持ってきても良かったが、
使わないし、あまり通信の量を増やしたくもないので用がない時は `gradle_secret_sample.properties` を使うようにした

done #3