### PR TITLE
メイン画面からはっしゅたぐ画面への遷移を作成

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
@@ -38,6 +38,10 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         main_drawer.closeDrawers()
+        when (item.itemId) {
+            R.id.nav_settings_hash_tag -> findNavController(R.id.main_nav_fragment)
+                .navigate(R.id.action_mainFragment_to_hashtagSettingFragment)
+        }
         return NavigationUI.onNavDestinationSelected(
             item,
             findNavController(R.id.main_nav_fragment)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
@@ -3,13 +3,12 @@ package com.ntetz.android.nyannyanengine_android
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import androidx.navigation.findNavController
+import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
-import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.navigation.NavigationView
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
@@ -17,6 +16,7 @@ import kotlinx.android.synthetic.main.app_bar_main.*
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
 
     private lateinit var appBarConfiguration: AppBarConfiguration
+    private lateinit var navController: NavController
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,26 +25,23 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         val navHostFragment = supportFragmentManager
             .findFragmentById(R.id.main_nav_fragment) as NavHostFragment
-        val navController = navHostFragment.navController
+        navController = navHostFragment.navController
         appBarConfiguration = AppBarConfiguration(navController.graph, main_drawer)
         setupActionBarWithNavController(navController, appBarConfiguration)
-        main_nav_view.setupWithNavController(navController)
         main_nav_view.setNavigationItemSelectedListener(this)
     }
 
-    override fun onSupportNavigateUp(): Boolean {
-        return findNavController(R.id.main_nav_fragment).navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
-    }
+    override fun onSupportNavigateUp() = (
+            navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp())
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         main_drawer.closeDrawers()
         when (item.itemId) {
-            R.id.nav_settings_hash_tag -> findNavController(R.id.main_nav_fragment)
-                .navigate(R.id.action_mainFragment_to_hashtagSettingFragment)
+            R.id.nav_settings_hash_tag -> navController.navigate(R.id.action_mainFragment_to_hashtagSettingFragment)
         }
         return NavigationUI.onNavDestinationSelected(
             item,
-            findNavController(R.id.main_nav_fragment)
+            navController
         ) || super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
@@ -1,17 +1,20 @@
 package com.ntetz.android.nyannyanengine_android
 
 import android.os.Bundle
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.navigation.NavigationView
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
 
     private lateinit var appBarConfiguration: AppBarConfiguration
 
@@ -26,9 +29,18 @@ class MainActivity : AppCompatActivity() {
         appBarConfiguration = AppBarConfiguration(navController.graph, main_drawer)
         setupActionBarWithNavController(navController, appBarConfiguration)
         main_nav_view.setupWithNavController(navController)
+        main_nav_view.setNavigationItemSelectedListener(this)
     }
 
     override fun onSupportNavigateUp(): Boolean {
         return findNavController(R.id.main_nav_fragment).navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
+    }
+
+    override fun onNavigationItemSelected(item: MenuItem): Boolean {
+        main_drawer.closeDrawers()
+        return NavigationUI.onNavDestinationSelected(
+            item,
+            findNavController(R.id.main_nav_fragment)
+        ) || super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -2,10 +2,12 @@ package com.ntetz.android.nyannyanengine_android
 
 import com.ntetz.android.nyannyanengine_android.ui.main.MainViewModel
 import com.ntetz.android.nyannyanengine_android.ui.post_nekogo.PostNekogoViewModel
+import com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingViewModel
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 private val viewModelModule = module {
+    viewModel { HashtagSettingViewModel() }
     viewModel { MainViewModel() }
     viewModel { PostNekogoViewModel() }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingFragment.kt
@@ -1,0 +1,35 @@
+package com.ntetz.android.nyannyanengine_android.ui.setting.hashtag
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.ntetz.android.nyannyanengine_android.databinding.HashtagSettingFragmentBinding
+import org.koin.android.viewmodel.ext.android.viewModel
+
+class HashtagSettingFragment : Fragment() {
+
+    companion object {
+        fun newInstance() =
+            HashtagSettingFragment()
+    }
+
+    private val viewModel: HashtagSettingViewModel by viewModel()
+    private lateinit var binding: HashtagSettingFragmentBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = HashtagSettingFragmentBinding.inflate(inflater, container, false)
+        binding.viewModel = viewModel
+        binding.lifecycleOwner = this
+        return binding.root
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
@@ -1,0 +1,7 @@
+package com.ntetz.android.nyannyanengine_android.ui.setting.hashtag
+
+import androidx.lifecycle.ViewModel
+
+class HashtagSettingViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,11 @@
     tools:context=".MainActivity"
     tools:openDrawer="start">
 
+    <include
+        layout="@layout/app_bar_main"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/main_nav_view"
         android:layout_width="wrap_content"
@@ -17,10 +22,5 @@
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/nav_header_main"
         app:menu="@menu/activity_main_drawer" />
-
-    <include
-        layout="@layout/app_bar_main"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/hashtag_setting_fragment.xml
+++ b/app/src/main/res/layout/hashtag_setting_fragment.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingViewModel" />
+
+    </data>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="Hello World!" />
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -17,9 +17,16 @@
             app:exitAnim="@anim/nav_default_exit_anim"
             app:popEnterAnim="@anim/nav_default_pop_enter_anim"
             app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+        <action
+            android:id="@+id/action_mainFragment_to_hashtagSettingFragment"
+            app:destination="@id/hashtagSettingFragment" />
     </fragment>
     <fragment
         android:id="@+id/postNekogoFragment"
         android:name="com.ntetz.android.nyannyanengine_android.ui.post_nekogo.PostNekogoFragment"
         android:label="PostNekogoFragment" />
+    <fragment
+        android:id="@+id/hashtagSettingFragment"
+        android:name="com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingFragment"
+        android:label="HashtagSettingFragment" />
 </navigation>


### PR DESCRIPTION
Android Studio 3.6がデフォルトで吐き出すDrawer Navigation用のxmlは、メニュー内のタップがおかしいので注意。下記が大変参考になった。

https://neet-rookie.hatenablog.com/entry/2019/09/09/142358

related #17 
close #15