### PR TITLE
デザイン基盤の作成

### DIFF
--- a/app/src/main/res/drawable/side_nav_bar.xml
+++ b/app/src/main/res/drawable/side_nav_bar.xml
@@ -2,8 +2,7 @@
     android:shape="rectangle">
     <gradient
         android:angle="135"
-        android:centerColor="#009688"
-        android:endColor="#00695C"
-        android:startColor="#4DB6AC"
+        android:endColor="@color/colorPrimaryDark"
+        android:startColor="@color/colorPrimary"
         android:type="linear" />
 </shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,6 +20,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
+        android:theme="@style/MainDrawerTheme"
         app:headerLayout="@layout/nav_header_main"
         app:menu="@menu/activity_main_drawer" />
 

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -8,15 +7,12 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/main_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/hashtag_setting_cell.xml
+++ b/app/src/main/res/layout/hashtag_setting_cell.xml
@@ -18,6 +18,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:padding="@dimen/middle_margin"
         android:orientation="horizontal">
 
         <TextView
@@ -25,6 +26,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@{viewModel.settingsList[position]}"
+            android:textAppearance="@style/TextAppearance.MenuListEntry"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tool:text="Hashtag name"/>

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -2,15 +2,14 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/account_container_height"
+    android:layout_height="wrap_content"
     android:background="@drawable/side_nav_bar"
     android:gravity="bottom"
     android:orientation="vertical"
     android:paddingLeft="@dimen/middle_margin"
-    android:paddingTop="@dimen/middle_margin"
+    android:paddingTop="@dimen/large_margin"
     android:paddingRight="@dimen/middle_margin"
-    android:paddingBottom="@dimen/middle_margin"
-    android:theme="@style/ThemeOverlay.AppCompat.Dark">
+    android:paddingBottom="@dimen/middle_margin">
 
     <ImageView
         android:id="@+id/imageView"
@@ -25,12 +24,13 @@
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/small_margin"
         android:text="@string/default_twitter_name"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        android:textAppearance="@style/TextAppearance.SelfTwitterName" />
 
     <TextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/default_twitter_id" />
+        android:text="@string/default_twitter_id"
+        android:textAppearance="@style/TextAppearance.SelfTwitterId" />
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#6200EE</color>
-    <color name="colorPrimaryDark">#3700B3</color>
-    <color name="colorAccent">#03DAC5</color>
+    <color name="colorPrimary">#fdf6e3</color>
+    <color name="colorPrimaryDark">#cac3b1</color>
+    <color name="colorSecondary">#268ad2</color>
+    <color name="onPrimary">#002b36</color>
 </resources>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -4,5 +4,6 @@
     <dimen name="middle_margin">16dp</dimen>
     <dimen name="small_margin">8dp</dimen>
 
-    <dimen name="account_container_height">176dp</dimen>
+    <dimen name="large_text_size">24sp</dimen>
+    <dimen name="small_text_size">16sp</dimen>
 </resources>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -5,5 +5,6 @@
     <dimen name="small_margin">8dp</dimen>
 
     <dimen name="large_text_size">24sp</dimen>
+    <dimen name="middle_text_size">18sp</dimen>
     <dimen name="small_text_size">16sp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,20 +1,17 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">@color/colorSecondary</item>
+        <item name="titleTextColor">@color/onPrimary</item>
+        <item name="colorControlNormal">@color/onPrimary</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
-
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,4 +14,13 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="TextAppearance.SelfTwitterName" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textSize">@dimen/large_text_size</item>
+    </style>
+
+    <style name="TextAppearance.SelfTwitterId" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textSize">@dimen/small_text_size</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,6 +14,10 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="MainDrawerTheme" parent="Widget.AppCompat.Toolbar.Button.Navigation">
+        <item name="itemTextAppearance">@style/TextAppearance.MenuListEntry</item>
+    </style>
+
     <style name="TextAppearance.SelfTwitterName" parent="TextAppearance.AppCompat.Body1">
         <item name="android:textColor">@color/onPrimary</item>
         <item name="android:textSize">@dimen/large_text_size</item>
@@ -23,4 +27,10 @@
         <item name="android:textColor">@color/onPrimary</item>
         <item name="android:textSize">@dimen/small_text_size</item>
     </style>
+
+    <style name="TextAppearance.MenuListEntry" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textSize">@dimen/middle_text_size</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## デザイン

下記に基づき決定

- Solarizedの設定値 ( https://en.wikipedia.org/wiki/Solarized_(color_scheme) )
- Material Colorへの落とし込み
  - https://material.io/components/app-bars-top/#theming
  - https://material.io/resources/color/#!/?view.left=0&view.right=0&primary.color=fdf6e3&secondary.color=268ad2

## スクショ

|変更前|変更後|
|:---:|:---:|
|<img width="314" alt="スクリーンショット 2020-04-05 午後2 55 49" src="https://user-images.githubusercontent.com/38374045/78468109-46131980-774f-11ea-97c9-be72e64c2862.png">|<img width="316" alt="スクリーンショット 2020-04-05 午後2 54 51" src="https://user-images.githubusercontent.com/38374045/78468128-88d4f180-774f-11ea-8392-a67e6a27069e.png">|
|<img width="317" alt="スクリーンショット 2020-04-05 午後2 55 57" src="https://user-images.githubusercontent.com/38374045/78468111-4c08fa80-774f-11ea-90b1-53f4bda85532.png">|<img width="310" alt="スクリーンショット 2020-04-05 午後2 55 01" src="https://user-images.githubusercontent.com/38374045/78468130-8a061e80-774f-11ea-8013-e68a23918921.png">|
|<img width="317" alt="スクリーンショット 2020-04-05 午後2 56 06" src="https://user-images.githubusercontent.com/38374045/78468113-50351800-774f-11ea-83df-8b0f6549154d.png">|<img width="312" alt="スクリーンショット 2020-04-05 午後2 55 13" src="https://user-images.githubusercontent.com/38374045/78468134-8f636900-774f-11ea-9811-0ea60a0d42e2.png">|

close #16 
close #17 
close #47