### PR TITLE
Android 7においてメニューを開くと灰色の丸が表示されてしまう現象を修正

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,7 +14,7 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="MainDrawerTheme" parent="Widget.AppCompat.Toolbar.Button.Navigation">
+    <style name="MainDrawerTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="itemTextAppearance">@style/TextAppearance.MenuListEntry</item>
     </style>
 


### PR DESCRIPTION
自然な実装に修正
ちなみに、Android5と9では確認されない現象・・・

|変更前|変更後|
|:--:|:--:|
|![Screenshot_20200405-154125](https://user-images.githubusercontent.com/38374045/78468559-16b2db80-7754-11ea-9520-76552dbd533e.png)|![Screenshot_20200405-154032](https://user-images.githubusercontent.com/38374045/78468558-14508180-7754-11ea-8a33-36e0e690285b.png)|
