### PR TITLE
はっしゅたぐ設定値変更時、描画が二重に走ってしまう現象を修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
     testImplementation 'android.arch.core:core-testing:1.1.1'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:3.4.0'
     testImplementation 'com.google.truth:truth:1.0.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/IDefaultHashtagsDao.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/IDefaultHashtagsDao.kt
@@ -1,6 +1,5 @@
 package com.ntetz.android.nyannyanengine_android.model.dao.room
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -10,9 +9,6 @@ import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHas
 
 @Dao
 interface IDefaultHashtagsDao {
-    @Query("SELECT * FROM default_hashtags")
-    fun allRecords(): LiveData<List<DefaultHashtagRecord>>
-
     @Query("SELECT * FROM default_hashtags")
     fun getAll(): List<DefaultHashtagRecord>
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepository.kt
@@ -1,6 +1,5 @@
 package com.ntetz.android.nyannyanengine_android.model.repository
 
-import androidx.lifecycle.LiveData
 import com.ntetz.android.nyannyanengine_android.model.dao.room.IDefaultHashtagsDao
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHashtagRecord
 import kotlinx.coroutines.CoroutineScope
@@ -9,14 +8,21 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 interface IHashtagsRepository {
-    val allDefaultHashtagRecords: LiveData<List<DefaultHashtagRecord>>
+    suspend fun getDefaultHashtagRecords(scope: CoroutineScope): List<DefaultHashtagRecord>
     fun updateDefaultHashtagRecord(record: DefaultHashtagRecord, scope: CoroutineScope)
 }
 
 class HashtagsRepository(
-    private val defaultHashtagsDao: IDefaultHashtagsDao,
-    override val allDefaultHashtagRecords: LiveData<List<DefaultHashtagRecord>> = defaultHashtagsDao.allRecords()
+    private val defaultHashtagsDao: IDefaultHashtagsDao
 ) : IHashtagsRepository {
+
+    override suspend fun getDefaultHashtagRecords(scope: CoroutineScope): List<DefaultHashtagRecord> {
+        return withContext(scope.coroutineContext) {
+            withContext(Dispatchers.IO) {
+                defaultHashtagsDao.getAll()
+            }
+        }
+    }
 
     override fun updateDefaultHashtagRecord(record: DefaultHashtagRecord, scope: CoroutineScope) {
         scope.launch {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecase.kt
@@ -1,8 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
 import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Transformations
 import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHashtagRecord
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
@@ -10,7 +8,7 @@ import com.ntetz.android.nyannyanengine_android.model.repository.IHashtagsReposi
 import kotlinx.coroutines.CoroutineScope
 
 interface IHashtagUsecase {
-    val defaultHashtagComponents: LiveData<List<DefaultHashTagComponent>>
+    suspend fun getDefaultHashtags(scope: CoroutineScope): List<DefaultHashTagComponent>
     fun updateDefaultHashtag(component: DefaultHashTagComponent, scope: CoroutineScope)
 }
 
@@ -19,14 +17,9 @@ class HashtagUsecase(
     private val defaultHashtagConfig: IDefaultHashtagConfig,
     private val context: Context
 ) : IHashtagUsecase {
-    override val defaultHashtagComponents: LiveData<List<DefaultHashTagComponent>>
-        get() {
-            return Transformations.map(hashtagsRepository.allDefaultHashtagRecords) { savedList ->
-                savedList.mapNotNull {
-                    createDefaultHashtagComponent(it)
-                }
-            }
-        }
+    override suspend fun getDefaultHashtags(scope: CoroutineScope): List<DefaultHashTagComponent> {
+        return hashtagsRepository.getDefaultHashtagRecords(scope).mapNotNull { createDefaultHashtagComponent(it) }
+    }
 
     override fun updateDefaultHashtag(component: DefaultHashTagComponent, scope: CoroutineScope) {
         hashtagsRepository.updateDefaultHashtagRecord(createDefaultHashtagRecord(component), scope)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingFragment.kt
@@ -33,6 +33,7 @@ class HashtagSettingFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
+        viewModel.initialize()
 
         val adapter = HashtagSettingAdapter(viewModel, this)
         binding.hashtagList.adapter = adapter

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
@@ -1,13 +1,24 @@
 package com.ntetz.android.nyannyanengine_android.ui.setting.hashtag
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import com.ntetz.android.nyannyanengine_android.model.usecase.IHashtagUsecase
+import kotlinx.coroutines.launch
 
 class HashtagSettingViewModel(private val hashtagUsecase: IHashtagUsecase) : ViewModel() {
-    val defaultHashtagComponents: LiveData<List<DefaultHashTagComponent>> = hashtagUsecase.defaultHashtagComponents
+    private val _defaultHashtagComponents: MutableLiveData<List<DefaultHashTagComponent>> = MutableLiveData(listOf())
+    val defaultHashtagComponents: LiveData<List<DefaultHashTagComponent>>
+        get() = _defaultHashtagComponents
+
+    fun initialize() {
+        viewModelScope.launch {
+            _defaultHashtagComponents.postValue(hashtagUsecase.getDefaultHashtags(this))
+        }
+    }
+
     fun updateDefaultHashtagComponent(defaultHashtagComponent: DefaultHashTagComponent) {
         hashtagUsecase.updateDefaultHashtag(defaultHashtagComponent, viewModelScope)
     }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepositoryTests.kt
@@ -1,6 +1,5 @@
 package com.ntetz.android.nyannyanengine_android.model.repository
 
-import androidx.lifecycle.MutableLiveData
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.model.dao.room.IDefaultHashtagsDao
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHashtagRecord
@@ -33,7 +32,6 @@ class HashtagsRepositoryTests {
     @Test
     fun updateDefaultHashtagRecord_defaultHashtagsDaoのupdateOneが1度実行されること() = runBlocking {
         val testDefaultHashtagRecord = DefaultHashtagRecord(9999, true)
-        `when`(mockDefaultHashtagsDao.allRecords()).thenReturn(MutableLiveData(listOf()))
         doNothing().`when`(mockDefaultHashtagsDao).updateOne(testDefaultHashtagRecord)
 
         HashtagsRepository(mockDefaultHashtagsDao).updateDefaultHashtagRecord(testDefaultHashtagRecord, this)

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepositoryTests.kt
@@ -21,12 +21,12 @@ class HashtagsRepositoryTests {
     private lateinit var mockDefaultHashtagsDao: IDefaultHashtagsDao
 
     @Test
-    fun allDefaultHashtags_daoのgetAll由来の値が取得できること() {
-        `when`(mockDefaultHashtagsDao.allRecords()).thenReturn(
-            MutableLiveData(listOf(DefaultHashtagRecord(9999, true)))
+    fun getDefaultHashtagRecords_daoのgetAll由来の値が取得できること() = runBlocking {
+        `when`(mockDefaultHashtagsDao.getAll()).thenReturn(
+            listOf(DefaultHashtagRecord(9999, true))
         )
 
-        Truth.assertThat(HashtagsRepository(mockDefaultHashtagsDao).allDefaultHashtagRecords.value)
+        Truth.assertThat(HashtagsRepository(mockDefaultHashtagsDao).getDefaultHashtagRecords(this))
             .isEqualTo(listOf(DefaultHashtagRecord(9999, true)))
     }
 

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecaseTests.kt
@@ -1,8 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
 import android.content.Context
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.MutableLiveData
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
@@ -10,7 +8,6 @@ import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHas
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IHashtagsRepository
 import kotlinx.coroutines.runBlocking
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -31,59 +28,39 @@ class HashtagUsecaseTests {
     @Mock
     private lateinit var mockContext: Context
 
-    // この記述がないとLiveDataのobserveがランタイムエラーする
-    @Rule
-    @JvmField
-    val rule = InstantTaskExecutorRule()
-
     @Test
-    fun defaultHashtags_observeしないとnullを返すこと() {
-        `when`(mockHashtagRepository.allDefaultHashtagRecords).thenReturn(
-            MutableLiveData(listOf(DefaultHashtagRecord(1, true)))
+    fun getDefaultHashtagRecords_レポジトリにstringリソース有りidが登録されている時stringリソースが反映された値であること() = runBlocking {
+        `when`(mockHashtagRepository.getDefaultHashtagRecords(this)).thenReturn(
+            listOf(DefaultHashtagRecord(99999, true))
         )
+        `when`(mockDefaultHashtagConfig.getTextBodyId(99999)).thenReturn(R.string.settings_title_hashtag_engine)
+        `when`(mockContext.getString(R.string.settings_title_hashtag_engine)).thenReturn("#testHashtaaaag")
 
         Truth.assertThat(
             HashtagUsecase(
                 mockHashtagRepository,
                 mockDefaultHashtagConfig,
                 mockContext
-            ).defaultHashtagComponents.value
-        ).isNull()
-    }
-
-    @Test
-    fun defaultHashtags_レポジトリにstringリソース有りidが登録されている時stringリソースが反映された値であること() {
-        `when`(mockHashtagRepository.allDefaultHashtagRecords).thenReturn(
-            MutableLiveData(listOf(DefaultHashtagRecord(99999, true)))
+            ).getDefaultHashtags(this)
         )
-        `when`(mockDefaultHashtagConfig.getTextBodyId(99999)).thenReturn(R.string.settings_title_hashtag_engine)
-        `when`(mockContext.getString(R.string.settings_title_hashtag_engine)).thenReturn("#testHashtaaaag")
-
-        HashtagUsecase(
-            mockHashtagRepository,
-            mockDefaultHashtagConfig,
-            mockContext
-        ).defaultHashtagComponents.observeForever {
-            Truth.assertThat(it)
-                .isEqualTo(listOf(DefaultHashTagComponent(99999, "#testHashtaaaag", true)))
-        }
+            .isEqualTo(listOf(DefaultHashTagComponent(99999, "#testHashtaaaag", true)))
     }
 
     @Test
-    fun defaultHashtags_レポジトリにstringリソース無しidが登録されている時空であること() {
-        `when`(mockHashtagRepository.allDefaultHashtagRecords).thenReturn(
-            MutableLiveData(listOf(DefaultHashtagRecord(99999, true)))
+    fun getDefaultHashtagRecords_レポジトリにstringリソース無しidが登録されている時空であること() = runBlocking {
+        `when`(mockHashtagRepository.getDefaultHashtagRecords(this)).thenReturn(
+            listOf(DefaultHashtagRecord(99999, true))
         )
         `when`(mockDefaultHashtagConfig.getTextBodyId(99999)).thenReturn(null)
 
-        HashtagUsecase(
-            mockHashtagRepository,
-            mockDefaultHashtagConfig,
-            mockContext
-        ).defaultHashtagComponents.observeForever {
-            Truth.assertThat(it)
-                .isEqualTo(listOf<DefaultHashTagComponent>())
-        }
+        Truth.assertThat(
+            HashtagUsecase(
+                mockHashtagRepository,
+                mockDefaultHashtagConfig,
+                mockContext
+            ).getDefaultHashtags(this)
+        )
+            .isEqualTo(listOf<DefaultHashTagComponent>())
     }
 
     @Test


### PR DESCRIPTION
これまで、RoomのLiveDataを生でスイッチに購読させていたため、スイッチ自身がRoomを更新してしまうと描画が2度走るという不具合があった。
Roomからの読み出しをするのは画面表示時の一回だけになるようにした。

これにてはっしゅたぐ保存機能自体は完成🎊

related #18 