### PR TITLE
はっしゅたぐ設定画面のViewModelのテストを追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.4.0'
     testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/TestUtil.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/TestUtil.kt
@@ -1,0 +1,15 @@
+package com.ntetz.android.nyannyanengine_android
+
+import org.mockito.Mockito
+
+class TestUtil private constructor() {
+
+    companion object {
+        fun <T> any(): T {
+            Mockito.any<T>()
+            return nullReturn()
+        }
+
+        private fun <T> nullReturn(): T = null as T
+    }
+}

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
@@ -1,0 +1,84 @@
+package com.ntetz.android.nyannyanengine_android.ui.setting.hashtag
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth
+import com.ntetz.android.nyannyanengine_android.TestUtil
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
+import com.ntetz.android.nyannyanengine_android.model.usecase.IHashtagUsecase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class HashtagSettingViewModelTest {
+    @Mock
+    private lateinit var mockHashtagUsecase: IHashtagUsecase
+
+    // この記述がないとviewModelScopeのlaunchがランタイムエラーする
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    // この記述がないとviewModelScopeのlaunchがランタイムエラーする
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.IO)
+    }
+
+    // setMain(Dispatchers.IO)の対
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun initialize_getDefaultHashtagsが呼ばれること() = runBlocking {
+        `when`(mockHashtagUsecase.getDefaultHashtags(TestUtil.any())).thenReturn(listOf())
+        HashtagSettingViewModel(mockHashtagUsecase).initialize()
+        delay(10) // これがないとCIでコケる
+
+        verify(mockHashtagUsecase, times(1)).getDefaultHashtags(TestUtil.any())
+        return@runBlocking
+    }
+
+    @Test
+    fun initialize_対応するはっしゅたぐのliveDataが更新されること() = runBlocking {
+        `when`(mockHashtagUsecase.getDefaultHashtags(TestUtil.any())).thenReturn(
+            listOf(
+                DefaultHashTagComponent(
+                    9999,
+                    "#testHashtaaaagVM",
+                    true
+                )
+            )
+        )
+
+        val testViewModel = HashtagSettingViewModel(mockHashtagUsecase)
+        testViewModel.initialize()
+        delay(10) // イベント反映までの待ち時間
+
+        Truth.assertThat(testViewModel.defaultHashtagComponents.value).isEqualTo(
+            listOf(
+                DefaultHashTagComponent(
+                    9999,
+                    "#testHashtaaaagVM",
+                    true
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
`viewModelScope` で動く関数をテストするために、特殊な考慮が必要なところもあった。

これにて、はっしゅたぐ保存機能は完成🎉🎊

close #18 