### PR TITLE
apk化した後デコンパイルしても、秘匿系の情報が見えづらくなるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ app/nyan_nyan_engine_android_release.jks
 
 app/android-deploy-user-dev.json
 app/android-deploy-user-prd.json
+
+# Bundle secrets
+
+secure-config-master-lib.cpp

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,13 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+
+    // API用の設定値はあまり目立たせたくないのでNDKを利用
+    externalNativeBuild {
+        cmake {
+            path file('src/main/cpp/CMakeLists.txt')
+        }
+    }
 }
 
 buildscript {

--- a/app/src/dev/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterConfig.kt
+++ b/app/src/dev/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterConfig.kt
@@ -1,7 +1,18 @@
 package com.ntetz.android.nyannyanengine_android.model.config
 
 class TwitterConfig : ITwitterConfig {
-    override val callbackUrl: String = "https://nyannyanengine-ios-d.firebaseapp.com/authorized/"
-    override val apiSecret: String = "jkl456MNO"
-    override val consumerKey: String = "abcde123GHI"
+    override val callbackUrl: String = "https://nyannyanengine-android-d.firebaseapp.com/authorized/"
+    override val apiSecret: String
+        get() = getApiSecretFromJniDev()
+    override val consumerKey: String
+        get() = getConsumerKeyFromJniDev()
+
+    private external fun getApiSecretFromJniDev(): String
+    private external fun getConsumerKeyFromJniDev(): String
+
+    companion object {
+        init {
+            System.loadLibrary("secure-config-master-lib")
+        }
+    }
 }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,44 @@
+# For more information about using CMake with Android Studio, read the
+# documentation: https://d.android.com/studio/projects/add-native-code.html
+
+# Sets the minimum version of CMake required to build the native library.
+
+cmake_minimum_required(VERSION 3.4.1)
+
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+
+add_library( # Sets the name of the library.
+             secure-config-master-lib
+
+             # Sets the library as a shared library.
+             SHARED
+
+             # Provides a relative path to your source file(s).
+             secure-config-master-lib.cpp )
+
+# Searches for a specified prebuilt library and stores the path as a
+# variable. Because CMake includes system libraries in the search path by
+# default, you only need to specify the name of the public NDK library
+# you want to add. CMake verifies that the library exists before
+# completing its build.
+
+find_library( # Sets the name of the path variable.
+              log-lib
+
+              # Specifies the name of the NDK library that
+              # you want CMake to locate.
+              log )
+
+# Specifies libraries CMake should link to your target library. You
+# can link multiple libraries, such as libraries you define in this
+# build script, prebuilt third-party libraries, or system libraries.
+
+target_link_libraries( # Specifies the target library.
+                       secure-config-master-lib
+
+                       # Links the target library to the log library
+                       # included in the NDK.
+                       ${log-lib} )

--- a/app/src/main/cpp/secure-config-master-lib.sample.cpp
+++ b/app/src/main/cpp/secure-config-master-lib.sample.cpp
@@ -1,0 +1,38 @@
+//
+// Created by Tetsuya Nishikawa on 8/2/20.
+//
+
+#include <jni.h>
+#include <string>
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_ntetz_android_nyannyanengine_1android_model_config_TwitterConfig_getApiSecretFromJniDev(
+        JNIEnv *env,
+        jobject /* this */) {
+    std::string value = "jkl456MNO";
+    return env->NewStringUTF(value.c_str());
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_ntetz_android_nyannyanengine_1android_model_config_TwitterConfig_getConsumerKeyFromJniDev(
+        JNIEnv *env,
+        jobject /* this */) {
+    std::string value = "abcde123GHI";
+    return env->NewStringUTF(value.c_str());
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_ntetz_android_nyannyanengine_1android_model_config_TwitterConfig_getApiSecretFromJniPrd(
+        JNIEnv *env,
+        jobject /* this */) {
+    std::string value = "jkl456MNO";
+    return env->NewStringUTF(value.c_str());
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_ntetz_android_nyannyanengine_1android_model_config_TwitterConfig_getConsumerKeyFromJniPrd(
+        JNIEnv *env,
+        jobject /* this */) {
+    std::string hello = "abcde123GHI";
+    return env->NewStringUTF(hello.c_str());
+}

--- a/app/src/prd/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterConfig.kt
+++ b/app/src/prd/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterConfig.kt
@@ -1,7 +1,18 @@
 package com.ntetz.android.nyannyanengine_android.model.config
 
 class TwitterConfig : ITwitterConfig {
-    override val callbackUrl: String = "https://nyannyanengine-ios-d.firebaseapp.com/authorized/"
-    override val apiSecret: String = "jkl456MNO"
-    override val consumerKey: String = "abcde123GHI"
+    override val callbackUrl: String = "https://nyannyanengine.firebaseapp.com/authorized/"
+    override val apiSecret: String
+        get() = getApiSecretFromJniPrd()
+    override val consumerKey: String
+        get() = getConsumerKeyFromJniPrd()
+
+    private external fun getApiSecretFromJniPrd(): String
+    private external fun getConsumerKeyFromJniPrd(): String
+
+    companion object {
+        init {
+            System.loadLibrary("secure-config-master-lib")
+        }
+    }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
@@ -2,6 +2,7 @@ package com.ntetz.android.nyannyanengine_android.model.repository
 
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
+import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApiEndpoints
@@ -24,6 +25,9 @@ class AccountRepositoryTests {
     @Mock
     private lateinit var mockTwitterApi: ITwitterApi
 
+    @Mock
+    private lateinit var mockTwitterConfig: ITwitterConfig
+
     @Test
     fun getAuthorizationToken_Retrofitのレスポンス由来の値が得られること() = runBlocking {
         withContext(Dispatchers.IO) {
@@ -45,8 +49,15 @@ class AccountRepositoryTests {
                 .returningResponse("mockResponseString")
             `when`(mockTwitterApi.client).thenReturn(mockEndpoints)
 
+            `when`(mockTwitterConfig.apiSecret).thenReturn("")
+            `when`(mockTwitterConfig.consumerKey).thenReturn("")
+            `when`(mockTwitterConfig.callbackUrl).thenReturn("")
             val testRepository =
-                AccountRepository(twitterApi = mockTwitterApi, base64Encoder = TestUtil.mockBase64Encoder)
+                AccountRepository(
+                    twitterApi = mockTwitterApi,
+                    twitterConfig = mockTwitterConfig,
+                    base64Encoder = TestUtil.mockBase64Encoder
+                )
             Truth.assertThat(testRepository.getAuthorizationToken(this))
                 .isEqualTo("mockResponseString")
         }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,14 @@ stages:
     - script: |
         sudo ln -s $(appReleaseKeystore.secureFilePath) app/nyan_nyan_engine_android_release.jks
       displayName: 'リリースビルド署名用キーストアの参照をプロジェクト内部に設置'
+    - task: DownloadSecureFile@1
+      displayName: '秘匿系設定ファイルを取得'
+      name: privateBundle
+      inputs:
+        secureFile: secure-config-master-lib.cpp
+    - script: |
+        sudo ln -s $(privateBundle.secureFilePath) app/src/main/cpp/secure-config-master-lib.cpp
+      displayName: '秘匿系設定ファイルの参照をプロジェクト内部に設置'
     - task: Gradle@2
       displayName: 'dev環境Releaseビルドを配布'
       inputs:


### PR DESCRIPTION
Data classに値を直書きした従来の実装は、apkのデコンパイルで丸見えになって危険と考えたので、難読化した。
下記を参考にC++/NDKで実装。

https://developer.android.com/studio/projects/add-native-code