### PR TITLE
azure pipeline上で、ndkの参照がうまくできなかったのでバージョン指定

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ android {
     }
 
     // API用の設定値はあまり目立たせたくないのでNDKを利用
+    ndkVersion "21.3.6528147"
     externalNativeBuild {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')


### PR DESCRIPTION
#67 マージ時のデプロイ用ジョブがndk周りでコケた。下記を参考に修正

https://dev.azure.com/tetphi1dev/NyanNyanEngine-Android/_build/results?buildId=425&view=logs&j=19b7d7ba-fca1-5b63-7b24-96c185aef4af&t=5541c79e-42fd-5f90-7d0d-a5509b1efba1

https://github.com/microsoft/appcenter/issues/1728