### PR TITLE
ツイッターからの遷移でアプリを開けるようにする

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,6 +14,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/dev/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterConfig.kt
+++ b/app/src/dev/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterConfig.kt
@@ -1,7 +1,7 @@
 package com.ntetz.android.nyannyanengine_android.model.config
 
 class TwitterConfig : ITwitterConfig {
-    override val callbackUrl: String = "https://nyannyanengine-android-d.firebaseapp.com/authorized/"
+    override val callbackUrl: String = "https://nyannyanengine-ios-d.firebaseapp.com/authorized/"
     override val apiSecret: String
         get() = getApiSecretFromJniDev()
     override val consumerKey: String

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <nav-graph android:value="@navigation/main_nav_graph" />
         </activity>
     </application>
 

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -20,6 +20,12 @@
         <action
             android:id="@+id/action_mainFragment_to_hashtagSettingFragment"
             app:destination="@id/hashtagSettingFragment" />
+        <deepLink
+            android:id="@+id/dev_twitter_callback"
+            app:uri="https://nyannyanengine-ios-d.firebaseapp.com/authorized/" />
+        <deepLink
+            android:id="@+id/prod_twitter_callback"
+            app:uri="https://nyannyanengine.firebaseapp.com/authorized/" />
     </fragment>
     <fragment
         android:id="@+id/postNekogoFragment"


### PR DESCRIPTION
## 概要 

ツイッターからのリダイレクトでアプリを開けるようにします。
see #26

## 備考

product flavorに応じてドメインを変えたいなと思ったが難しそう。
`manifestPlaceholders` を用いたAndroidManifest.xmlへの注入は可能だが、
今回のようなビルド時に自動追記される箇所に関してはなんかうまくいかなそう

https://stackoverflow.com/questions/42971558/android-deeplink-per-flavor

## 参考資料

https://developer.android.com/guide/navigation/navigation-deep-link