### PR TITLE
Android6.0以上において、リリースビルドにおいてtwitter認証コールバックがモーダルナシで開くようにした

### DIFF
--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -22,9 +22,11 @@
             app:destination="@id/hashtagSettingFragment" />
         <deepLink
             android:id="@+id/dev_twitter_callback"
+            android:autoVerify="true"
             app:uri="https://nyannyanengine-ios-d.firebaseapp.com/authorized/" />
         <deepLink
             android:id="@+id/prod_twitter_callback"
+            android:autoVerify="true"
             app:uri="https://nyannyanengine.firebaseapp.com/authorized/" />
     </fragment>
     <fragment


### PR DESCRIPTION
## 概要

App Linksに対応させた

see #26 

## 備考

サーバー側では、開発/本番環境のドメインに対して下記を参考にファイルを設置

- `/.well-known/assetlinks.json`
- `/robots.txt`

https://developer.android.com/training/app-links/verify-site-associations?hl=ja#multi-host

## 参考資料

公式のままにAndroidManifest.xmlのintent-filter要素一箇所に追記しても動かなかった。直接でもIDEからでも、Navigation用のxmlに書いてあげる必要があった。

