### PR TITLE
警告を潰した

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,28 +95,28 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.firebase:firebase-appdistribution-gradle:2.0.0'
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:2.0.1'
     }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.room:room-ktx:2.2.5'
     kapt "androidx.room:room-compiler:2.2.5"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
     testImplementation 'android.arch.core:core-testing:1.1.1'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.mockito:mockito-core:3.4.0'
     testImplementation 'com.google.truth:truth:1.0.1'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.2.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     def koin_version = "2.0.1"
     implementation "org.koin:koin-core:$koin_version"
@@ -126,15 +126,15 @@ dependencies {
     implementation "org.koin:koin-android-viewmodel:$koin_version"
     implementation "org.koin:koin-android-ext:$koin_version"
 
-    implementation 'com.squareup.retrofit2:retrofit:2.6.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-scalars:2.6.0'
     testImplementation 'com.squareup.retrofit2:retrofit-mock:2.6.0'
 
     ktlint "com.pinterest:ktlint:0.36.0"
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.0'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.1'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.3.1'
 
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.1'
 
     // jaxbの記述は、dataBinding有効化時でも、java 11環境でgradle checkを行えるようにするためのもの。
     if (project.hasProperty('kapt')) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,11 @@ android {
 
     compileSdkVersion 30
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         jvmTarget = "1.8"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         }
     }
 
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     kotlinOptions {
         jvmTarget = "1.8"
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         applicationId "com.ntetz.android.nyannyanengine_android"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <issue id="UnusedAttribute">
+        <ignore path="res/navigation/main_nav_graph.xml" />
+    </issue>
     <issue id="HardcodedText" severity="error" />
 </lint>

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -22,6 +22,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/large_margin"
             android:layout_marginBottom="@dimen/large_margin"
+            android:contentDescription="@string/home_timeline_description_post_nekogo"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -3,6 +3,8 @@
     <string name="default_twitter_id">\@NNyansu</string>
     <string name="nav_header_desc">Account info</string>
 
+    <string name="home_timeline_description_post_nekogo">Post cat language</string>
+
     <string name="settings_title_hashtag_engine">#MeowMeowEngine</string>
     <string name="settings_title_hashtag_nadenade">#PetMeMeeow🧶</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -3,6 +3,8 @@
     <string name="default_twitter_id">\@NNyansu</string>
     <string name="nav_header_desc">アカウント情報</string>
 
+    <string name="home_timeline_description_post_nekogo">ねこ語をツイート</string>
+
     <string name="settings_title_hashtag_engine">#にゃんにゃんエンジン</string>
     <string name="settings_title_hashtag_nadenade">#なでてほしいにゃ🧶</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="default_twitter_id">\@NNyansu</string>
     <string name="nav_header_desc">Account info</string>
 
+    <string name="home_timeline_description_post_nekogo">Post cat language</string>
+
     <string name="settings_title_hashtag_engine">#MeowMeowEngine</string>
     <string name="settings_title_hashtag_nadenade">#PetMeMeeow🧶</string>
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
## 概要

増えてきたので一括対応

## 参考

下記が参考になった

### 途中発生したエラー

```
Invoke-customs are only supported starting with Android O (--min-api 26)
```

https://qiita.com/pongi/items/02596f6990f63a7fb4db

### lintを無視するための設定検索

```
~/Library/Android/sdk/tools/bin/lint --list | less
```

https://backport.net/blog/2018/05/28/android_lint_issue_id/