### PR TITLE
twitterのaccess_token API対応

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,22 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
+apply plugin: "androidx.navigation.safeargs.kotlin"
+
 def keyPropertiesFile = rootProject.file("app/gradle_secret.properties")
 def keyProperties = new Properties()
 keyProperties.load(new FileInputStream(keyPropertiesFile))
@@ -106,7 +108,7 @@ buildscript {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -15,6 +15,7 @@ import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.ui.main.MainViewModel
 import com.ntetz.android.nyannyanengine_android.ui.post_nekogo.PostNekogoViewModel
 import com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingViewModel
+import com.ntetz.android.nyannyanengine_android.ui.sign_in.SignInViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -39,6 +40,7 @@ private val viewModelModule = module {
         HashtagSettingViewModel(usecase)
     }
     viewModel { MainViewModel() }
+    viewModel { SignInViewModel() }
     viewModel { PostNekogoViewModel() }
 }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -29,7 +29,10 @@ private val viewModelModule = module {
 
     single { ApplicationUsecase(getUserProfileDatabase(androidContext())) }
     single<IAccountUsecase> {
-        val repository = AccountRepository(TwitterApi)
+        val repository = AccountRepository(
+            twitterApi = TwitterApi,
+            twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao()
+        )
         AccountUsecase(repository)
     }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -42,7 +42,7 @@ private val viewModelModule = module {
         val usecase = HashtagUsecase(repository, get(), androidContext())
         HashtagSettingViewModel(usecase)
     }
-    viewModel { MainViewModel() }
+    viewModel { MainViewModel(get()) }
     viewModel { SignInViewModel(get()) }
     viewModel { PostNekogoViewModel() }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -40,7 +40,7 @@ private val viewModelModule = module {
         HashtagSettingViewModel(usecase)
     }
     viewModel { MainViewModel() }
-    viewModel { SignInViewModel() }
+    viewModel { SignInViewModel(get()) }
     viewModel { PostNekogoViewModel() }
 }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterEndpoints.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/TwitterEndpoints.kt
@@ -8,6 +8,8 @@ object TwitterEndpoints {
     const val authorizePagePath: String = "oauth/authorize"
 
     const val requestTokenPath: String = "oauth/request_token"
+    const val accessTokenPath: String = "oauth/access_token"
     const val requestTokenMethod: String = "POST"
+    const val accessTokenMethod: String = "POST"
     const val requestTokenOauthCallbackParamName: String = "oauth_callback"
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/ITwitterApiEndpoints.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/ITwitterApiEndpoints.kt
@@ -4,8 +4,16 @@ import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import retrofit2.Call
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface ITwitterApiEndpoints {
     @POST(TwitterEndpoints.requestTokenPath)
     fun requestToken(@Header(TwitterEndpoints.authorizationHeaderName) authorization: String): Call<String>
+
+    @POST("oauth/access_token")
+    fun accessToken(
+        @Query("oauth_verifier") oauthVerifier: String,
+        @Query("oauth_token") oauthToken: String,
+        @Header(TwitterEndpoints.authorizationHeaderName) authorization: String
+    ): Call<String>
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/ITwitterUserDao.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/ITwitterUserDao.kt
@@ -1,0 +1,16 @@
+package com.ntetz.android.nyannyanengine_android.model.dao.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+
+@Dao
+interface ITwitterUserDao {
+    @Query("SELECT * FROM twitter_users")
+    fun getAll(): List<TwitterUserRecord>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun upsert(twitterUserRecord: TwitterUserRecord)
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/TwitterUserRecord.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/TwitterUserRecord.kt
@@ -1,0 +1,13 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.dao.room
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "twitter_users")
+data class TwitterUserRecord(
+    @PrimaryKey @ColumnInfo(name = "id") val id: String,
+    @ColumnInfo(name = "oauth_token") val oauthToken: String,
+    @ColumnInfo(name = "oauth_token_secret") val oauthTokenSecret: String,
+    @ColumnInfo(name = "screen_name") val screenName: String
+)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/UserProfileDatabase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/UserProfileDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
 import com.ntetz.android.nyannyanengine_android.model.dao.room.IDefaultHashtagsDao
+import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.koin.core.KoinComponent
@@ -14,11 +15,13 @@ import org.koin.core.inject
 interface IUserProfileDatabase {
     fun initialize()
     fun defaultHashtagsDao(): IDefaultHashtagsDao
+    fun twitterUserDao(): ITwitterUserDao
 }
 
-@Database(entities = arrayOf(DefaultHashtagRecord::class), version = 1, exportSchema = false)
+@Database(entities = arrayOf(DefaultHashtagRecord::class, TwitterUserRecord::class), version = 1, exportSchema = false)
 abstract class UserProfileDatabase : RoomDatabase(), KoinComponent, IUserProfileDatabase {
     abstract override fun defaultHashtagsDao(): IDefaultHashtagsDao
+    abstract override fun twitterUserDao(): ITwitterUserDao
     private val defaultHashtagConfig: IDefaultHashtagConfig by inject()
 
     override fun initialize() {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/account/SignInResultComponent.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/account/SignInResultComponent.kt
@@ -1,0 +1,7 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.usecase.account
+
+data class SignInResultComponent(
+    val isSucceeded: Boolean,
+    val errorCode: Int? = null,
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
@@ -19,6 +19,7 @@ import retrofit2.Response
 interface IAccountRepository {
     suspend fun getAuthorizationToken(scope: CoroutineScope): String?
     suspend fun getAccessToken(oauthVerifier: String, oauthToken: String, scope: CoroutineScope): Response<String?>?
+    suspend fun loadTwitterUser(scope: CoroutineScope): TwitterUserRecord?
     suspend fun saveTwitterUser(record: TwitterUserRecord, scope: CoroutineScope)
 }
 
@@ -83,6 +84,14 @@ class AccountRepository(
                         authorization = authorization
                     )
                     .execute()
+            }
+        }
+    }
+
+    override suspend fun loadTwitterUser(scope: CoroutineScope): TwitterUserRecord? {
+        return withContext(scope.coroutineContext) {
+            withContext(Dispatchers.IO) {
+                twitterUserDao.getAll().firstOrNull()
             }
         }
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
@@ -8,6 +8,7 @@ import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.TwitterRequestMetadata
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.TwitterSignParam
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.TwitterSignature
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
 import com.ntetz.android.nyannyanengine_android.util.Base64Encoder
 import com.ntetz.android.nyannyanengine_android.util.IBase64Encoder
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +19,7 @@ import retrofit2.Response
 interface IAccountRepository {
     suspend fun getAuthorizationToken(scope: CoroutineScope): String?
     suspend fun getAccessToken(oauthVerifier: String, oauthToken: String, scope: CoroutineScope): Response<String?>?
+    suspend fun saveTwitterUser(record: TwitterUserRecord, scope: CoroutineScope)
 }
 
 class AccountRepository(
@@ -81,6 +83,14 @@ class AccountRepository(
                         authorization = authorization
                     )
                     .execute()
+            }
+        }
+    }
+
+    override suspend fun saveTwitterUser(record: TwitterUserRecord, scope: CoroutineScope) {
+        return withContext(scope.coroutineContext) {
+            withContext(Dispatchers.IO) {
+                twitterUserDao.upsert(record)
             }
         }
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
@@ -4,6 +4,7 @@ import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
+import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.TwitterRequestMetadata
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.TwitterSignParam
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.TwitterSignature
@@ -22,7 +23,8 @@ interface IAccountRepository {
 class AccountRepository(
     private val twitterApi: ITwitterApi,
     private val twitterConfig: ITwitterConfig = TwitterConfig(),
-    private val base64Encoder: IBase64Encoder = Base64Encoder()
+    private val base64Encoder: IBase64Encoder = Base64Encoder(),
+    private val twitterUserDao: ITwitterUserDao
 ) : IAccountRepository {
     override suspend fun getAuthorizationToken(scope: CoroutineScope): String? {
         val additionalHeaders = listOf(

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
@@ -12,9 +12,11 @@ import com.ntetz.android.nyannyanengine_android.util.IBase64Encoder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import retrofit2.Response
 
 interface IAccountRepository {
     suspend fun getAuthorizationToken(scope: CoroutineScope): String?
+    suspend fun getAccessToken(oauthVerifier: String, oauthToken: String, scope: CoroutineScope): Response<String?>?
 }
 
 class AccountRepository(
@@ -44,6 +46,39 @@ class AccountRepository(
                     .requestToken(authorization)
                     .execute()
                     .body()
+            }
+        }
+    }
+
+    override suspend fun getAccessToken(
+        oauthVerifier: String,
+        oauthToken: String,
+        scope: CoroutineScope
+    ): Response<String?>? {
+        val fullPath = listOf(
+            TwitterEndpoints.accessTokenPath,
+            "?oauth_verifier=$oauthVerifier&oauth_token=$oauthToken"
+        ).joinToString(separator = "")
+        return withContext(scope.coroutineContext) {
+            val requestMetadata = TwitterRequestMetadata(
+                method = TwitterEndpoints.accessTokenMethod,
+                path = fullPath,
+                twitterConfig = twitterConfig
+            )
+            val authorization = TwitterSignature(
+                requestMetadata = requestMetadata,
+                twitterConfig = twitterConfig,
+                base64Encoder = base64Encoder
+            ).getOAuthValue()
+
+            withContext(Dispatchers.IO) {
+                twitterApi.client
+                    .accessToken(
+                        oauthVerifier = oauthVerifier,
+                        oauthToken = oauthToken,
+                        authorization = authorization
+                    )
+                    .execute()
             }
         }
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecase.kt
@@ -2,11 +2,13 @@ package com.ntetz.android.nyannyanengine_android.model.usecase
 
 import android.net.Uri
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IAccountRepository
 import kotlinx.coroutines.CoroutineScope
 
 interface IAccountUsecase {
     suspend fun createAuthorizationEndpoint(scope: CoroutineScope): Uri?
+    suspend fun fetchAccessToken(): SignInResultComponent?
 }
 
 class AccountUsecase(private val accountRepository: IAccountRepository) : IAccountUsecase {
@@ -17,5 +19,10 @@ class AccountUsecase(private val accountRepository: IAccountRepository) : IAccou
         ).joinToString("")
         val queryStr = accountRepository.getAuthorizationToken(scope) ?: return null
         return Uri.parse("$urlStr?$queryStr")
+    }
+
+    override suspend fun fetchAccessToken(): SignInResultComponent? {
+        // TODO: 通信とつなげる
+        return SignInResultComponent(isSucceeded = true)
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecase.kt
@@ -14,6 +14,8 @@ interface IAccountUsecase {
         oauthToken: String,
         scope: CoroutineScope
     ): SignInResultComponent?
+
+    suspend fun loadAccessToken(scope: CoroutineScope): TwitterUserRecord?
 }
 
 class AccountUsecase(private val accountRepository: IAccountRepository) : IAccountUsecase {
@@ -57,6 +59,10 @@ class AccountUsecase(private val accountRepository: IAccountRepository) : IAccou
             )
         }
         return SignInResultComponent(isSucceeded = true)
+    }
+
+    override suspend fun loadAccessToken(scope: CoroutineScope): TwitterUserRecord? {
+        return accountRepository.loadTwitterUser(scope)
     }
 
     private fun createTwitterUserRecord(tokenApiResponse: String?): TwitterUserRecord? {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.databinding.MainFragmentBinding
@@ -27,6 +28,10 @@ class MainFragment : Fragment() {
         binding = MainFragmentBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
+        viewModel.twitterUserEvent.observe(viewLifecycleOwner, Observer {
+            println("record is $it")
+        })
+        viewModel.initialize()
         return binding.root
     }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.databinding.MainFragmentBinding
 import org.koin.android.viewmodel.ext.android.viewModel
@@ -18,7 +17,6 @@ class MainFragment : Fragment() {
     }
 
     private val viewModel: MainViewModel by viewModel()
-    private val args: MainFragmentArgs by navArgs()
     private lateinit var binding: MainFragmentBinding
 
     override fun onCreateView(
@@ -29,7 +27,6 @@ class MainFragment : Fragment() {
         binding = MainFragmentBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
-        println("oauth token is ${this.args.oauthToken}")
         return binding.root
     }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.databinding.MainFragmentBinding
 import org.koin.android.viewmodel.ext.android.viewModel
@@ -17,6 +18,7 @@ class MainFragment : Fragment() {
     }
 
     private val viewModel: MainViewModel by viewModel()
+    private val args: MainFragmentArgs by navArgs()
     private lateinit var binding: MainFragmentBinding
 
     override fun onCreateView(
@@ -27,6 +29,7 @@ class MainFragment : Fragment() {
         binding = MainFragmentBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
+        println("oauth token is ${this.args.oauthToken}")
         return binding.root
     }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
@@ -1,5 +1,23 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import kotlinx.coroutines.launch
 
-class MainViewModel : ViewModel()
+class MainViewModel(private val accountUsecase: IAccountUsecase) : ViewModel() {
+    private val _twitterUserEvent: MutableLiveData<TwitterUserRecord?> =
+        MutableLiveData()
+
+    val twitterUserEvent: LiveData<TwitterUserRecord?>
+        get() = _twitterUserEvent
+
+    fun initialize() {
+        viewModelScope.launch {
+            _twitterUserEvent.postValue(accountUsecase.loadAccessToken(this))
+        }
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.ntetz.android.nyannyanengine_android.R
@@ -32,6 +33,10 @@ class SignInFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         println("oauth token is ${this.args.oauthToken}")
-        findNavController().navigate(R.id.action_singInFragment_to_mainFragment)
+        viewModel.signInEvent.observe(viewLifecycleOwner, Observer {
+            println("sign in finished! $it")
+            findNavController().navigate(R.id.action_singInFragment_to_mainFragment)
+        })
+        viewModel.executeSignIn()
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
@@ -32,11 +32,13 @@ class SignInFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        println("oauth token is ${this.args.oauthToken}")
         viewModel.signInEvent.observe(viewLifecycleOwner, Observer {
             println("sign in finished! $it")
             findNavController().navigate(R.id.action_singInFragment_to_mainFragment)
         })
-        viewModel.executeSignIn()
+        viewModel.executeSignIn(
+            oauthVerifier = this.args.oauthVerifier,
+            oauthToken = this.args.oauthToken
+        )
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
@@ -1,0 +1,37 @@
+package com.ntetz.android.nyannyanengine_android.ui.sign_in
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.ntetz.android.nyannyanengine_android.R
+
+class SignInFragment : Fragment() {
+
+    private val args: SignInFragmentArgs by navArgs()
+
+    companion object {
+        fun newInstance() = SignInFragment()
+    }
+
+    private lateinit var viewModel: SignInViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.sign_in_fragment, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        viewModel = ViewModelProvider(this).get(SignInViewModel::class.java)
+
+        println("oauth token is ${this.args.oauthToken}")
+        findNavController().navigate(R.id.action_singInFragment_to_mainFragment)
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.ntetz.android.nyannyanengine_android.R
+import org.koin.android.viewmodel.ext.android.viewModel
 
 class SignInFragment : Fragment() {
 
@@ -17,7 +18,7 @@ class SignInFragment : Fragment() {
         fun newInstance() = SignInFragment()
     }
 
-    private lateinit var viewModel: SignInViewModel
+    private val viewModel: SignInViewModel by viewModel()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -29,7 +30,6 @@ class SignInFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(SignInViewModel::class.java)
 
         println("oauth token is ${this.args.oauthToken}")
         findNavController().navigate(R.id.action_singInFragment_to_mainFragment)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
@@ -1,0 +1,7 @@
+package com.ntetz.android.nyannyanengine_android.ui.sign_in
+
+import androidx.lifecycle.ViewModel
+
+class SignInViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
@@ -1,7 +1,21 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_in
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
+import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import kotlinx.coroutines.launch
 
-class SignInViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
+class SignInViewModel(private val accountUsecase: IAccountUsecase) : ViewModel() {
+    private val _signInEvent: MutableLiveData<SignInResultComponent?> = MutableLiveData()
+    val signInEvent: LiveData<SignInResultComponent?>
+        get() = _signInEvent
+
+    fun executeSignIn() {
+        viewModelScope.launch {
+            _signInEvent.postValue(accountUsecase.fetchAccessToken())
+        }
+    }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
@@ -13,9 +13,21 @@ class SignInViewModel(private val accountUsecase: IAccountUsecase) : ViewModel()
     val signInEvent: LiveData<SignInResultComponent?>
         get() = _signInEvent
 
-    fun executeSignIn() {
+    fun executeSignIn(oauthVerifier: String?, oauthToken: String?) {
         viewModelScope.launch {
-            _signInEvent.postValue(accountUsecase.fetchAccessToken())
+            if (oauthVerifier == null || oauthToken == null) {
+                // TODO: 基本的には発生しないが、クエリストリングなしでアプリに遷移してきた時のエラーハンドリング
+                _signInEvent.postValue(null)
+                println("tootteruyo")
+                return@launch
+            }
+            _signInEvent.postValue(
+                accountUsecase.fetchAccessToken(
+                    oauthVerifier = oauthVerifier,
+                    oauthToken = oauthToken,
+                    scope = this
+                )
+            )
         }
     }
 }

--- a/app/src/main/res/layout/sign_in_fragment.xml
+++ b/app/src/main/res/layout/sign_in_fragment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.sign_in.SignInFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hello World!" />
+
+</FrameLayout>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -23,11 +23,21 @@
         <deepLink
             android:id="@+id/dev_twitter_callback"
             android:autoVerify="true"
-            app:uri="https://nyannyanengine-ios-d.firebaseapp.com/authorized/" />
+            app:uri="https://nyannyanengine-ios-d.firebaseapp.com/authorized/?oauth_token={oauthToken}&amp;oauth_verifier={oauthVerifier}" />
         <deepLink
             android:id="@+id/prod_twitter_callback"
             android:autoVerify="true"
-            app:uri="https://nyannyanengine.firebaseapp.com/authorized/" />
+            app:uri="https://nyannyanengine.firebaseapp.com/authorized/?oauth_token={oauthToken}&amp;oauth_verifier={oauthVerifier}" />
+        <argument
+            android:name="oauthToken"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="null" />
+        <argument
+            android:name="oauthVerifier"
+            app:argType="string"
+            app:nullable="true"
+            android:defaultValue="null" />
     </fragment>
     <fragment
         android:id="@+id/postNekogoFragment"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -20,6 +20,23 @@
         <action
             android:id="@+id/action_mainFragment_to_hashtagSettingFragment"
             app:destination="@id/hashtagSettingFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/postNekogoFragment"
+        android:name="com.ntetz.android.nyannyanengine_android.ui.post_nekogo.PostNekogoFragment"
+        android:label="PostNekogoFragment" />
+    <fragment
+        android:id="@+id/hashtagSettingFragment"
+        android:name="com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingFragment"
+        android:label="HashtagSettingFragment" />
+    <fragment
+        android:id="@+id/signInFragment"
+        android:name="com.ntetz.android.nyannyanengine_android.ui.sign_in.SignInFragment"
+        android:label="sign_in_fragment"
+        tools:layout="@layout/sign_in_fragment">
+        <action
+            android:id="@+id/action_singInFragment_to_mainFragment"
+            app:destination="@id/mainFragment" />
         <deepLink
             android:id="@+id/dev_twitter_callback"
             android:autoVerify="true"
@@ -39,12 +56,4 @@
             app:nullable="true"
             android:defaultValue="null" />
     </fragment>
-    <fragment
-        android:id="@+id/postNekogoFragment"
-        android:name="com.ntetz.android.nyannyanengine_android.ui.post_nekogo.PostNekogoFragment"
-        android:label="PostNekogoFragment" />
-    <fragment
-        android:id="@+id/hashtagSettingFragment"
-        android:name="com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingFragment"
-        android:label="HashtagSettingFragment" />
 </navigation>

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/TestUtil.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/TestUtil.kt
@@ -1,8 +1,14 @@
 package com.ntetz.android.nyannyanengine_android
 
+import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.util.IBase64Encoder
 import java.util.*
+import java.util.concurrent.TimeUnit
 import org.mockito.Mockito
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+import retrofit2.mock.MockRetrofit
+import retrofit2.mock.NetworkBehavior
 
 class TestUtil private constructor() {
 
@@ -13,6 +19,24 @@ class TestUtil private constructor() {
             Mockito.any<T>()
             return nullReturn()
         }
+
+        val mockNormalRetrofit: MockRetrofit
+            get() {
+                val retrofit = Retrofit
+                    .Builder()
+                    .baseUrl(TwitterEndpoints.baseEndpoint)
+                    .addConverterFactory(ScalarsConverterFactory.create())
+                    .build()
+                val behavior = NetworkBehavior.create().also {
+                    it.setDelay(0, TimeUnit.MILLISECONDS)
+                    it.setFailurePercent(0)
+                    it.setErrorPercent(0)
+                }
+                return MockRetrofit
+                    .Builder(retrofit)
+                    .networkBehavior(behavior)
+                    .build()
+            }
 
         private fun <T> nullReturn(): T = null as T
     }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
@@ -6,12 +6,15 @@ import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApiEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 
@@ -47,5 +50,79 @@ class AccountRepositoryTests {
             Truth.assertThat(testRepository.getAuthorizationToken(this))
                 .isEqualTo("mockResponseString")
         }
+    }
+
+    @Test
+    fun getAccessToken_Retrofitのレスポンス由来の値が得られること() = runBlocking {
+        withContext(Dispatchers.IO) {
+            val mockEndpoints = TestUtil.mockNormalRetrofit
+                .create(ITwitterApiEndpoints::class.java)
+                .returningResponse("mockTokenResponseString")
+            `when`(mockTwitterApi.client).thenReturn(mockEndpoints)
+
+            `when`(mockTwitterConfig.apiSecret).thenReturn("")
+            `when`(mockTwitterConfig.consumerKey).thenReturn("")
+            val testRepository =
+                AccountRepository(
+                    twitterApi = mockTwitterApi,
+                    twitterConfig = mockTwitterConfig,
+                    base64Encoder = TestUtil.mockBase64Encoder,
+                    twitterUserDao = mockTwitterUserDao
+                )
+            Truth.assertThat(testRepository.getAccessToken("", "", this)!!.body())
+                .isEqualTo("mockTokenResponseString")
+        }
+    }
+
+    @Test
+    fun loadTwitterUser_daoのgetAll由来の値が取得できること() = runBlocking {
+        `when`(mockTwitterUserDao.getAll()).thenReturn(
+            listOf(
+                TwitterUserRecord(
+                    "iDdum1",
+                    oauthToken = "tokDum1",
+                    oauthTokenSecret = "secDum1",
+                    screenName = "scDum1"
+                )
+            )
+        )
+
+        Truth.assertThat(
+            AccountRepository(
+                twitterApi = mockTwitterApi,
+                twitterConfig = mockTwitterConfig,
+                base64Encoder = TestUtil.mockBase64Encoder,
+                twitterUserDao = mockTwitterUserDao
+            ).loadTwitterUser(this)
+        )
+            .isEqualTo(
+                TwitterUserRecord(
+                    "iDdum1",
+                    oauthToken = "tokDum1",
+                    oauthTokenSecret = "secDum1",
+                    screenName = "scDum1"
+                )
+            )
+    }
+
+    @Test
+    fun saveTwitterUser_twitterUserDaoのupsertが1度実行されること() = runBlocking {
+        val testTwitterUserRecord = TwitterUserRecord(
+            "iDdum2",
+            oauthToken = "tokDum2",
+            oauthTokenSecret = "secDum2",
+            screenName = "scDum2"
+        )
+        Mockito.doNothing().`when`(mockTwitterUserDao).upsert(testTwitterUserRecord)
+
+        AccountRepository(
+            twitterApi = mockTwitterApi,
+            twitterConfig = mockTwitterConfig,
+            base64Encoder = TestUtil.mockBase64Encoder,
+            twitterUserDao = mockTwitterUserDao
+        ).saveTwitterUser(testTwitterUserRecord, this)
+        delay(20) // これがないと、initialize内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+
+        Mockito.verify(mockTwitterUserDao, Mockito.times(1)).upsert(testTwitterUserRecord)
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
@@ -6,6 +6,7 @@ import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApiEndpoints
+import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -27,6 +28,9 @@ class AccountRepositoryTests {
 
     @Mock
     private lateinit var mockTwitterConfig: ITwitterConfig
+
+    @Mock
+    private lateinit var mockTwitterUserDao: ITwitterUserDao
 
     @Test
     fun getAuthorizationToken_Retrofitのレスポンス由来の値が得られること() = runBlocking {
@@ -56,7 +60,8 @@ class AccountRepositoryTests {
                 AccountRepository(
                     twitterApi = mockTwitterApi,
                     twitterConfig = mockTwitterConfig,
-                    base64Encoder = TestUtil.mockBase64Encoder
+                    base64Encoder = TestUtil.mockBase64Encoder,
+                    twitterUserDao = mockTwitterUserDao
                 )
             Truth.assertThat(testRepository.getAuthorizationToken(this))
                 .isEqualTo("mockResponseString")

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
@@ -3,11 +3,9 @@ package com.ntetz.android.nyannyanengine_android.model.repository
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
-import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApiEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -16,10 +14,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
-import retrofit2.Retrofit
-import retrofit2.converter.scalars.ScalarsConverterFactory
-import retrofit2.mock.MockRetrofit
-import retrofit2.mock.NetworkBehavior
 
 @RunWith(MockitoJUnitRunner::class)
 class AccountRepositoryTests {
@@ -35,20 +29,7 @@ class AccountRepositoryTests {
     @Test
     fun getAuthorizationToken_Retrofitのレスポンス由来の値が得られること() = runBlocking {
         withContext(Dispatchers.IO) {
-            val retrofit = Retrofit
-                .Builder()
-                .baseUrl(TwitterEndpoints.baseEndpoint)
-                .addConverterFactory(ScalarsConverterFactory.create())
-                .build()
-            val behavior = NetworkBehavior.create().also {
-                it.setDelay(0, TimeUnit.MILLISECONDS)
-                it.setFailurePercent(0)
-                it.setErrorPercent(0)
-            }
-            val mockEndpoints = MockRetrofit
-                .Builder(retrofit)
-                .networkBehavior(behavior)
-                .build()
+            val mockEndpoints = TestUtil.mockNormalRetrofit
                 .create(ITwitterApiEndpoints::class.java)
                 .returningResponse("mockResponseString")
             `when`(mockTwitterApi.client).thenReturn(mockEndpoints)

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecaseTests.kt
@@ -3,11 +3,9 @@ package com.ntetz.android.nyannyanengine_android.model.usecase
 import android.net.Uri
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
-import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApiEndpoints
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IAccountRepository
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -18,10 +16,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
-import retrofit2.Retrofit
-import retrofit2.converter.scalars.ScalarsConverterFactory
-import retrofit2.mock.MockRetrofit
-import retrofit2.mock.NetworkBehavior
 
 @RunWith(MockitoJUnitRunner::class)
 class AccountUsecaseTests {
@@ -56,21 +50,7 @@ class AccountUsecaseTests {
     fun fetchAccessToken_Uriが不正な時エラー用の値を返すこと() = runBlocking {
         // Robolectricを入れたくない関係上、android.Uriクラスがnullを返すことを応用している
         withContext(Dispatchers.IO) {
-            val retrofit = Retrofit
-                .Builder()
-                .baseUrl(TwitterEndpoints.baseEndpoint)
-                .addConverterFactory(ScalarsConverterFactory.create())
-                .build()
-            val behavior = NetworkBehavior.create().also {
-                it.setDelay(0, TimeUnit.MILLISECONDS)
-                it.setFailurePercent(0)
-                it.setErrorPercent(0)
-            }
-            val mockResponse = MockRetrofit
-                .Builder(retrofit)
-                .networkBehavior(behavior)
-                .build()
-                .create(ITwitterApiEndpoints::class.java)
+            val mockResponse = TestUtil.mockNormalRetrofit.create(ITwitterApiEndpoints::class.java)
                 .returningResponse("oauth_token=mTk&oauth_token_secret=mSc&user_id=mkI&screen_name=mNm")
                 .accessToken("dummy", "dummy2", "dummy3")
                 .execute()
@@ -93,21 +73,7 @@ class AccountUsecaseTests {
     @Test
     fun fetchAccessToken_accessTokenAPIがレポジトリを通して1度呼ばれること() = runBlocking {
         withContext(Dispatchers.IO) {
-            val retrofit = Retrofit
-                .Builder()
-                .baseUrl(TwitterEndpoints.baseEndpoint)
-                .addConverterFactory(ScalarsConverterFactory.create())
-                .build()
-            val behavior = NetworkBehavior.create().also {
-                it.setDelay(0, TimeUnit.MILLISECONDS)
-                it.setFailurePercent(0)
-                it.setErrorPercent(0)
-            }
-            val mockResponse = MockRetrofit
-                .Builder(retrofit)
-                .networkBehavior(behavior)
-                .build()
-                .create(ITwitterApiEndpoints::class.java)
+            val mockResponse = TestUtil.mockNormalRetrofit.create(ITwitterApiEndpoints::class.java)
                 .returningResponse("oauth_token=mTk&oauth_token_secret=mSc&user_id=mkI&screen_name=mNm")
                 .accessToken("dummy", "dummy2", "dummy3")
                 .execute()

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
@@ -1,0 +1,82 @@
+package com.ntetz.android.nyannyanengine_android.ui.main
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth
+import com.ntetz.android.nyannyanengine_android.TestUtil
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class MainViewModelTests {
+    @Mock
+    private lateinit var mockAccountUsecase: IAccountUsecase
+
+    // この記述がないとviewModelScopeのlaunchがランタイムエラーする
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    // この記述がないとviewModelScopeのlaunchがランタイムエラーする
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.IO)
+    }
+
+    // setMain(Dispatchers.IO)の対
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun initialize_loadAccessTokenが呼ばれること() = runBlocking {
+        Mockito.`when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(null)
+        MainViewModel(mockAccountUsecase).initialize()
+        delay(10) // これがないとCIでコケる
+
+        Mockito.verify(mockAccountUsecase, Mockito.times(1))
+            .loadAccessToken(TestUtil.any())
+        return@runBlocking
+    }
+
+    @Test
+    fun initialize_対応するアクセストークン取得結果liveDataが更新されること() = runBlocking {
+        Mockito.`when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(
+            TwitterUserRecord(
+                id = "dummyId",
+                oauthToken = "dummyTkn",
+                oauthTokenSecret = "dummyScrt",
+                screenName = "dummyScName"
+            )
+        )
+
+        val testViewModel = MainViewModel(mockAccountUsecase)
+        testViewModel.initialize()
+        delay(10) // これがないとCIでコケる
+
+        Truth.assertThat(testViewModel.twitterUserEvent.value).isEqualTo(
+            TwitterUserRecord(
+                id = "dummyId",
+                oauthToken = "dummyTkn",
+                oauthTokenSecret = "dummyScrt",
+                screenName = "dummyScName"
+            )
+        )
+        return@runBlocking
+    }
+}

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
@@ -2,6 +2,7 @@ package com.ntetz.android.nyannyanengine_android.ui.sign_in
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
+import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import kotlinx.coroutines.Dispatchers
@@ -46,17 +47,17 @@ class SignInViewModelTests {
 
     @Test
     fun executeSignIn_fetchAccessTokenが呼ばれること() = runBlocking {
-        `when`(mockAccountUsecase.fetchAccessToken()).thenReturn(null)
-        SignInViewModel(mockAccountUsecase).executeSignIn()
+        `when`(mockAccountUsecase.fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(null)
+        SignInViewModel(mockAccountUsecase).executeSignIn("authVerifierDummy", "oauthTokenDummy")
         delay(10) // これがないとCIでコケる
 
-        verify(mockAccountUsecase, times(1)).fetchAccessToken()
+        verify(mockAccountUsecase, times(1)).fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())
         return@runBlocking
     }
 
     @Test
     fun executeSignIn_対応するアクセストークン取得結果liveDataが更新されること() = runBlocking {
-        `when`(mockAccountUsecase.fetchAccessToken()).thenReturn(
+        `when`(mockAccountUsecase.fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(
             SignInResultComponent(
                 isSucceeded = true,
                 errorMessage = "testTokenEventTest"
@@ -64,7 +65,7 @@ class SignInViewModelTests {
         )
 
         val testViewModel = SignInViewModel(mockAccountUsecase)
-        testViewModel.executeSignIn()
+        testViewModel.executeSignIn("authVerifierDummy", "oauthTokenDummy")
         delay(10) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.signInEvent.value).isEqualTo(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
@@ -1,0 +1,78 @@
+package com.ntetz.android.nyannyanengine_android.ui.sign_in
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
+import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class SignInViewModelTests {
+    @Mock
+    private lateinit var mockAccountUsecase: IAccountUsecase
+
+    // この記述がないとviewModelScopeのlaunchがランタイムエラーする
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    // この記述がないとviewModelScopeのlaunchがランタイムエラーする
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.IO)
+    }
+
+    // setMain(Dispatchers.IO)の対
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun executeSignIn_fetchAccessTokenが呼ばれること() = runBlocking {
+        `when`(mockAccountUsecase.fetchAccessToken()).thenReturn(null)
+        SignInViewModel(mockAccountUsecase).executeSignIn()
+        delay(10) // これがないとCIでコケる
+
+        verify(mockAccountUsecase, times(1)).fetchAccessToken()
+        return@runBlocking
+    }
+
+    @Test
+    fun executeSignIn_対応するアクセストークン取得結果liveDataが更新されること() = runBlocking {
+        `when`(mockAccountUsecase.fetchAccessToken()).thenReturn(
+            SignInResultComponent(
+                isSucceeded = true,
+                errorMessage = "testTokenEventTest"
+            )
+        )
+
+        val testViewModel = SignInViewModel(mockAccountUsecase)
+        testViewModel.executeSignIn()
+        delay(10) // これがないとCIでコケる
+
+        Truth.assertThat(testViewModel.signInEvent.value).isEqualTo(
+            SignInResultComponent(
+                isSucceeded = true,
+                errorMessage = "testTokenEventTest"
+            )
+        )
+        return@runBlocking
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         
     }
     dependencies {
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.1'
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 


### PR DESCRIPTION
## 概要

リダイレクトで受け取ったトークンを用いて、Twitterのアクセストークンを取得、そして保存するようにした。
また、メイン画面において表示時にトークン情報を確認しにいくようにした

close #27 
close #28 