### PR TITLE
ツイートをキャッシュするようにした

### DIFF
--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -40,7 +40,8 @@ private val viewModelModule = module {
     }
     single<ITweetsUsecase> {
         val tweetRepository = TweetsRepository(
-            twitterApi = TwitterApi
+            twitterApi = TwitterApi,
+            cachedTweetsDao = getUserProfileDatabase(androidContext()).cachedTweetsDao()
         )
         val accountRepository = AccountRepository(
             twitterApi = TwitterApi,

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/ICachedTweetsDao.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/ICachedTweetsDao.kt
@@ -13,4 +13,7 @@ interface ICachedTweetsDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun upsert(cachedTweetRecords: List<CachedTweetRecord>)
+
+    @Query("DELETE FROM cached_tweets")
+    fun deleteAll()
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/ICachedTweetsDao.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/room/ICachedTweetsDao.kt
@@ -1,0 +1,16 @@
+package com.ntetz.android.nyannyanengine_android.model.dao.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.CachedTweetRecord
+
+@Dao
+interface ICachedTweetsDao {
+    @Query("SELECT * FROM cached_tweets")
+    fun getAll(): List<CachedTweetRecord>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun upsert(cachedTweetRecords: List<CachedTweetRecord>)
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/CachedTweetRecord.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/CachedTweetRecord.kt
@@ -1,0 +1,15 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.dao.room
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "cached_tweets")
+data class CachedTweetRecord(
+    @PrimaryKey @ColumnInfo(name = "id") val id: Long,
+    @ColumnInfo(name = "text") val text: String,
+    @ColumnInfo(name = "created_at") val createdAt: String,
+    @ColumnInfo(name = "user_name") val userName: String,
+    @ColumnInfo(name = "user_screen_name") val userScreenName: String,
+    @ColumnInfo(name = "profile_image_url_https") val profileImageUrlHttps: String
+)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/UserProfileDatabase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/UserProfileDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
+import com.ntetz.android.nyannyanengine_android.model.dao.room.ICachedTweetsDao
 import com.ntetz.android.nyannyanengine_android.model.dao.room.IDefaultHashtagsDao
 import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
 import kotlinx.coroutines.GlobalScope
@@ -16,12 +17,18 @@ interface IUserProfileDatabase {
     fun initialize()
     fun defaultHashtagsDao(): IDefaultHashtagsDao
     fun twitterUserDao(): ITwitterUserDao
+    fun cachedTweetsDao(): ICachedTweetsDao
 }
 
-@Database(entities = arrayOf(DefaultHashtagRecord::class, TwitterUserRecord::class), version = 1, exportSchema = false)
+@Database(
+    entities = arrayOf(DefaultHashtagRecord::class, TwitterUserRecord::class, CachedTweetRecord::class),
+    version = 1,
+    exportSchema = false
+)
 abstract class UserProfileDatabase : RoomDatabase(), KoinComponent, IUserProfileDatabase {
     abstract override fun defaultHashtagsDao(): IDefaultHashtagsDao
     abstract override fun twitterUserDao(): ITwitterUserDao
+    abstract override fun cachedTweetsDao(): ICachedTweetsDao
     private val defaultHashtagConfig: IDefaultHashtagConfig by inject()
 
     override fun initialize() {

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepositoryTests.kt
@@ -5,8 +5,10 @@ import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApiEndpoints
+import com.ntetz.android.nyannyanengine_android.model.dao.room.ICachedTweetsDao
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.User
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.CachedTweetRecord
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -15,6 +17,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
@@ -25,8 +29,11 @@ class TweetsRepositoryTests {
     @Mock
     private lateinit var mockTwitterConfig: ITwitterConfig
 
+    @Mock
+    private lateinit var mockCachedTweetsDao: ICachedTweetsDao
+
     @Test
-    fun getTweets_Retrofitのレスポンス由来の値が得られること() = runBlocking {
+    fun getTweets_キャッシュ非存在時Retrofitのレスポンス由来の値が得られること() = runBlocking {
         withContext(Dispatchers.IO) {
             val mockEndpoints = TestUtil.mockNormalRetrofit
                 .create(ITwitterApiEndpoints::class.java)
@@ -44,11 +51,13 @@ class TweetsRepositoryTests {
 
             `when`(mockTwitterConfig.apiSecret).thenReturn("")
             `when`(mockTwitterConfig.consumerKey).thenReturn("")
+            `when`(mockCachedTweetsDao.getAll()).thenReturn(listOf())
             val testRepository =
                 TweetsRepository(
                     twitterApi = mockTwitterApi,
                     twitterConfig = mockTwitterConfig,
-                    base64Encoder = TestUtil.mockBase64Encoder
+                    base64Encoder = TestUtil.mockBase64Encoder,
+                    cachedTweetsDao = mockCachedTweetsDao
                 )
             Truth.assertThat(testRepository.getTweets(TwitterUserRecord("", "", "", ""), this)!!)
                 .isEqualTo(
@@ -58,6 +67,107 @@ class TweetsRepositoryTests {
                             text = "dummyTextRepo",
                             createdAt = "3 gatsu 2 nichi",
                             user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
+                        )
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun getTweets_キャッシュ非存在時Retrofitのレスポンス取得後キャッシュ用テーブル初期化が走ること() = runBlocking {
+        withContext(Dispatchers.IO) {
+            val mockEndpoints = TestUtil.mockNormalRetrofit
+                .create(ITwitterApiEndpoints::class.java)
+                .returningResponse(
+                    listOf(
+                        Tweet(
+                            id = 2828,
+                            text = "dummyTextRepo",
+                            createdAt = "3 gatsu 2 nichi",
+                            user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
+                        )
+                    )
+                )
+            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+
+            `when`(mockTwitterConfig.apiSecret).thenReturn("")
+            `when`(mockTwitterConfig.consumerKey).thenReturn("")
+            `when`(mockCachedTweetsDao.getAll()).thenReturn(listOf())
+            val testRepository =
+                TweetsRepository(
+                    twitterApi = mockTwitterApi,
+                    twitterConfig = mockTwitterConfig,
+                    base64Encoder = TestUtil.mockBase64Encoder,
+                    cachedTweetsDao = mockCachedTweetsDao
+                )
+            testRepository.getTweets(TwitterUserRecord("", "", "", ""), this)!!
+
+            verify(mockCachedTweetsDao, times(1)).deleteAll()
+        }
+    }
+
+    @Test
+    fun getTweets_キャッシュ非存在時Retrofitのレスポンス取得後キャッシュ用テーブル更新が走ること() = runBlocking {
+        withContext(Dispatchers.IO) {
+            val mockEndpoints = TestUtil.mockNormalRetrofit
+                .create(ITwitterApiEndpoints::class.java)
+                .returningResponse(
+                    listOf(
+                        Tweet(
+                            id = 2828,
+                            text = "dummyTextRepo",
+                            createdAt = "3 gatsu 2 nichi",
+                            user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
+                        )
+                    )
+                )
+            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+
+            `when`(mockTwitterConfig.apiSecret).thenReturn("")
+            `when`(mockTwitterConfig.consumerKey).thenReturn("")
+            `when`(mockCachedTweetsDao.getAll()).thenReturn(listOf())
+            val testRepository =
+                TweetsRepository(
+                    twitterApi = mockTwitterApi,
+                    twitterConfig = mockTwitterConfig,
+                    base64Encoder = TestUtil.mockBase64Encoder,
+                    cachedTweetsDao = mockCachedTweetsDao
+                )
+            testRepository.getTweets(TwitterUserRecord("", "", "", ""), this)!!
+
+            verify(mockCachedTweetsDao, times(1)).upsert(TestUtil.any())
+        }
+    }
+
+    @Test
+    fun getTweets_キャッシュ存在時Room内の値が得られること() = runBlocking {
+        withContext(Dispatchers.IO) {
+            `when`(mockCachedTweetsDao.getAll()).thenReturn(
+                listOf(
+                    CachedTweetRecord(
+                        id = 3838,
+                        text = "dummyCachedTweet",
+                        createdAt = "kinou",
+                        userName = "cachedUser",
+                        userScreenName = "cachedScreenUser",
+                        profileImageUrlHttps = "https://ntetz.com/test.jpg"
+                    )
+                )
+            )
+            val testRepository =
+                TweetsRepository(
+                    twitterApi = mockTwitterApi,
+                    twitterConfig = mockTwitterConfig,
+                    cachedTweetsDao = mockCachedTweetsDao
+                )
+            Truth.assertThat(testRepository.getTweets(TwitterUserRecord("", "", "", ""), this)!!)
+                .isEqualTo(
+                    listOf(
+                        Tweet(
+                            id = 3838,
+                            text = "dummyCachedTweet",
+                            createdAt = "kinou",
+                            user = User("cachedUser", "cachedScreenUser", "https://ntetz.com/test.jpg")
                         )
                     )
                 )


### PR DESCRIPTION
## 概要

キャッシュをRoomに持たせるようにした。
RDBぽいことをしないのでSharedPreferenceでも良い気がしたが、機能自体の実装と、context取り回しの実装とを作るのが面倒だったのでこうした。

close #74