### PR TITLE
Firebase周りの処理を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ app/android-deploy-user-prd.json
 # Bundle secrets
 
 secure-config-master-lib.cpp
+
+# Firebase secrets
+
+app/src/dev/google-services.json
+app/src/prd/google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.firebase.appdistribution'
+apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
@@ -126,6 +127,9 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+
+    implementation platform('com.google.firebase:firebase-bom:26.2.0')
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 
     def koin_version = "2.0.1"
     implementation "org.koin:koin-core:$koin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.firebase.appdistribution'
 apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
@@ -131,6 +132,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:26.2.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
+    implementation 'com.google.firebase:firebase-crashlytics-ktx'
 
     def koin_version = "2.0.1"
     implementation "org.koin:koin-core:$koin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,6 +133,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-firestore:22.0.1'
 
     def koin_version = "2.0.1"
     implementation "org.koin:koin-core:$koin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,7 @@ dependencies {
 
     implementation platform('com.google.firebase:firebase-bom:26.2.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-auth-ktx'
 
     def koin_version = "2.0.1"
     implementation "org.koin:koin-core:$koin_version"

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.google.android.material.navigation.NavigationView
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.NyanNyanUserComponent
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
@@ -60,6 +61,11 @@ class MainActivity : AppCompatActivity(), CoroutineScope, NavigationView.OnNavig
         main_nav_view.getHeaderView(0).twitter_name.text = name
         main_nav_view.getHeaderView(0).twitter_screen_name.text = screenName
         main_nav_view.menu.findItem(R.id.nav_auth).title = authMenuTitle
+    }
+
+    fun updateNyanNyanUserInfo(userInfo: NyanNyanUserComponent?) {
+        main_nav_view.getHeaderView(0).current_rank.text = userInfo?.getCurrentRank(this)
+        main_nav_view.getHeaderView(0).current_extends.text = userInfo?.currentExtends?.toString()
     }
 
     override fun onSupportNavigateUp() = (

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -64,8 +64,8 @@ private val viewModelModule = module {
 
     viewModel {
         val dao = getUserProfileDatabase(androidContext()).defaultHashtagsDao()
-        val repository = HashtagsRepository(dao)
-        val usecase = HashtagUsecase(repository, get(), androidContext())
+        val repository = HashtagsRepository(get(), dao)
+        val usecase = HashtagUsecase(repository, androidContext())
         HashtagSettingViewModel(usecase, get())
     }
     viewModel { MainViewModel(get(), get(), get()) }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -59,7 +59,13 @@ private val viewModelModule = module {
             twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao(),
             firebaseClient = get()
         )
-        TweetsUsecase(tweetsRepository = tweetRepository, accountRepository = accountRepository)
+        val hashtagsRepository =
+            HashtagsRepository(get(), getUserProfileDatabase(androidContext()).defaultHashtagsDao())
+        TweetsUsecase(
+            tweetsRepository = tweetRepository,
+            accountRepository = accountRepository,
+            hashtagsRepository = hashtagsRepository
+        )
     }
 
     viewModel {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -41,7 +41,8 @@ private val viewModelModule = module {
     single<IAccountUsecase> {
         val repository = AccountRepository(
             twitterApi = TwitterApi,
-            twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao()
+            twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao(),
+            firebaseClient = get()
         )
         AccountUsecase(repository)
     }
@@ -55,7 +56,8 @@ private val viewModelModule = module {
         )
         val accountRepository = AccountRepository(
             twitterApi = TwitterApi,
-            twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao()
+            twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao(),
+            firebaseClient = get()
         )
         TweetsUsecase(tweetsRepository = tweetRepository, accountRepository = accountRepository)
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -3,18 +3,23 @@ package com.ntetz.android.nyannyanengine_android
 import android.content.Context
 import com.ntetz.android.nyannyanengine_android.model.config.DefaultHashtagConfig
 import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.FirebaseClient
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.IFirebaseClient
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.TwitterApi
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.IUserProfileDatabase
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.UserProfileDatabase
 import com.ntetz.android.nyannyanengine_android.model.repository.AccountRepository
 import com.ntetz.android.nyannyanengine_android.model.repository.HashtagsRepository
+import com.ntetz.android.nyannyanengine_android.model.repository.MetricsRepository
 import com.ntetz.android.nyannyanengine_android.model.repository.TweetsRepository
 import com.ntetz.android.nyannyanengine_android.model.usecase.AccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ApplicationUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.HashtagUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.TweetsUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.UserActionUsecase
 import com.ntetz.android.nyannyanengine_android.ui.main.MainViewModel
 import com.ntetz.android.nyannyanengine_android.ui.post_nekogo.PostNekogoViewModel
 import com.ntetz.android.nyannyanengine_android.ui.setting.hashtag.HashtagSettingViewModel
@@ -30,6 +35,7 @@ object MainModule {
 
 private val viewModelModule = module {
     single<IDefaultHashtagConfig> { DefaultHashtagConfig() }
+    single<IFirebaseClient> { FirebaseClient() }
 
     single { ApplicationUsecase(getUserProfileDatabase(androidContext())) }
     single<IAccountUsecase> {
@@ -38,6 +44,10 @@ private val viewModelModule = module {
             twitterUserDao = getUserProfileDatabase(androidContext()).twitterUserDao()
         )
         AccountUsecase(repository)
+    }
+    single<IUserActionUsecase> {
+        val metricsRepository = MetricsRepository(get())
+        UserActionUsecase(metricsRepository)
     }
     single<ITweetsUsecase> {
         val tweetRepository = TweetsRepository(
@@ -54,12 +64,12 @@ private val viewModelModule = module {
         val dao = getUserProfileDatabase(androidContext()).defaultHashtagsDao()
         val repository = HashtagsRepository(dao)
         val usecase = HashtagUsecase(repository, get(), androidContext())
-        HashtagSettingViewModel(usecase)
+        HashtagSettingViewModel(usecase, get())
     }
-    viewModel { MainViewModel(get(), get()) }
-    viewModel { SignInViewModel(get()) }
-    viewModel { SignOutViewModel(get()) }
-    viewModel { PostNekogoViewModel(get(), get()) }
+    viewModel { MainViewModel(get(), get(), get()) }
+    viewModel { SignInViewModel(get(), get()) }
+    viewModel { SignOutViewModel(get(), get()) }
+    viewModel { PostNekogoViewModel(get(), get(), get()) }
 }
 
 private fun getUserProfileDatabase(context: Context): IUserProfileDatabase = UserProfileDatabase.getDatabase(context)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -37,7 +37,7 @@ private val viewModelModule = module {
     single<IDefaultHashtagConfig> { DefaultHashtagConfig() }
     single<IFirebaseClient> { FirebaseClient() }
 
-    single { ApplicationUsecase(getUserProfileDatabase(androidContext())) }
+    single { ApplicationUsecase(getUserProfileDatabase(androidContext()), get()) }
     single<IAccountUsecase> {
         val repository = AccountRepository(
             twitterApi = TwitterApi,

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -59,7 +59,7 @@ private val viewModelModule = module {
     viewModel { MainViewModel(get(), get()) }
     viewModel { SignInViewModel(get()) }
     viewModel { SignOutViewModel(get()) }
-    viewModel { PostNekogoViewModel(get()) }
+    viewModel { PostNekogoViewModel(get(), get()) }
 }
 
 private fun getUserProfileDatabase(context: Context): IUserProfileDatabase = UserProfileDatabase.getDatabase(context)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultHashtagConfig.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultHashtagConfig.kt
@@ -7,19 +7,22 @@ import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHas
 interface IDefaultHashtagConfig {
     fun getInitializationRecords(): List<DefaultHashtagRecord>
     fun getTextBodyId(hashtagId: Int): Int?
+    fun getNekosanPoint(hashtagId: Int): Int?
     suspend fun populate(defaultHashtagsDao: IDefaultHashtagsDao)
 }
 
 class DefaultHashtagConfig : IDefaultHashtagConfig {
     private val entries = mapOf(
-        1 to DefaultHashtag(R.string.settings_title_hashtag_engine, true),
-        2 to DefaultHashtag(R.string.settings_title_hashtag_nadenade, false)
+        1 to DefaultHashtag(R.string.settings_title_hashtag_engine, true, 30),
+        2 to DefaultHashtag(R.string.settings_title_hashtag_nadenade, false, 50)
     )
 
     override fun getInitializationRecords(): List<DefaultHashtagRecord> =
         entries.map { DefaultHashtagRecord(it.key, it.value.defaultEnabled) }
 
     override fun getTextBodyId(hashtagId: Int): Int? = entries[hashtagId]?.textBodyId
+
+    override fun getNekosanPoint(hashtagId: Int): Int? = entries[hashtagId]?.nekosanPoint
 
     override suspend fun populate(defaultHashtagsDao: IDefaultHashtagsDao) {
         val registeredHashtagIds = defaultHashtagsDao.getAll().map { it.id }
@@ -33,5 +36,6 @@ class DefaultHashtagConfig : IDefaultHashtagConfig {
 
 private data class DefaultHashtag(
     val textBodyId: Int,
-    val defaultEnabled: Boolean
+    val defaultEnabled: Boolean,
+    val nekosanPoint: Int
 )

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultUserConfig.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultUserConfig.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.config
 
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanUser
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.User
 
 object DefaultUserConfig {
@@ -8,4 +9,6 @@ object DefaultUserConfig {
         screenName = "NNyansu",
         profileImageUrlHttps = "https://nyannyanengine.firebaseapp.com/assets/nyannya_sensei.png"
     )
+
+    val notSignInNyanNyanUser = NyanNyanUser(id = "28", nekosanPoint = 99999, tweetCount = 0)
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
@@ -1,0 +1,21 @@
+package com.ntetz.android.nyannyanengine_android.model.dao.firebase
+
+import com.google.firebase.analytics.ktx.analytics
+import com.google.firebase.analytics.ktx.logEvent
+import com.google.firebase.ktx.Firebase
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
+
+interface IFirebaseClient {
+    fun logEvent(type: AnalyticsEvent, textParams: Map<String, String>?, numParams: Map<String, Int>?)
+}
+
+class FirebaseClient : IFirebaseClient {
+    private val analytics = Firebase.analytics
+
+    override fun logEvent(type: AnalyticsEvent, textParams: Map<String, String>?, numParams: Map<String, Int>?) {
+        analytics.logEvent(type.title) {
+            textParams?.forEach { param(it.key, it.value) }
+            numParams?.forEach { param(it.key, it.value.toLong()) }
+        }
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
@@ -1,19 +1,46 @@
 package com.ntetz.android.nyannyanengine_android.model.dao.firebase
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
+import com.ntetz.android.nyannyanengine_android.model.config.DefaultUserConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanRank
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanUser
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import java.util.*
+import kotlin.collections.HashMap
 
 interface IFirebaseClient {
+    val nyanNyanConfigEvent: LiveData<NyanNyanConfig?>
+    val nyanNyanUserEvent: LiveData<NyanNyanUser?>
+
     fun initialize()
     fun logEvent(type: AnalyticsEvent, textParams: Map<String, String>?, numParams: Map<String, Int>?)
+    fun fetchNyanNyanUser(twitterUserRecord: TwitterUserRecord?)
+    fun fetchNyanNyanConfig()
 }
 
 class FirebaseClient : IFirebaseClient {
     private val analytics = Firebase.analytics
     private val auth = Firebase.auth
+    private val db = FirebaseFirestore.getInstance()
+
+    private val usersCollectionName = "users"
+    private val configCollectionName = "config"
+
+    private val _nyanNyanConfigEvent = MutableLiveData<NyanNyanConfig?>()
+    override val nyanNyanConfigEvent: LiveData<NyanNyanConfig?>
+        get() = _nyanNyanConfigEvent
+
+    private val _nyanNyanUserEvent = MutableLiveData<NyanNyanUser?>()
+    override val nyanNyanUserEvent: LiveData<NyanNyanUser?>
+        get() = _nyanNyanUserEvent
 
     override fun initialize() {
         auth.signInAnonymously()
@@ -24,5 +51,44 @@ class FirebaseClient : IFirebaseClient {
             textParams?.forEach { param(it.key, it.value) }
             numParams?.forEach { param(it.key, it.value.toLong()) }
         }
+    }
+
+    override fun fetchNyanNyanUser(twitterUserRecord: TwitterUserRecord?) {
+        if (twitterUserRecord == null) {
+            _nyanNyanUserEvent.postValue(
+                DefaultUserConfig.notSignInNyanNyanUser
+            )
+            return
+        }
+        db.collection(usersCollectionName).document(twitterUserRecord.sealedUserId)
+            .get()
+            .addOnSuccessListener {
+                val nekosanPoint = (it.data?.get("np") as? Long)?.toInt() ?: return@addOnSuccessListener
+                val tweetCount = (it.data?.get("tc") as? Long)?.toInt() ?: return@addOnSuccessListener
+                _nyanNyanUserEvent.postValue(
+                    NyanNyanUser(id = it.id, nekosanPoint = nekosanPoint, tweetCount = tweetCount)
+                )
+            }
+    }
+
+    override fun fetchNyanNyanConfig() {
+        db.collection(configCollectionName)
+            .get()
+            .addOnSuccessListener { allData ->
+                val nekosanPointMultiplier = allData.first { it.id == "np_multiplier" }["v"].toString().toInt()
+
+                val ranksMasterDocumentName = if (Locale.getDefault().language == "ja") "np_rank_ja" else "np_rank_en"
+                val ranks = HashMap<Int, NyanNyanRank>()
+                allData.first { it.id == ranksMasterDocumentName }
+                    .data.forEach {
+                        val key = it.key.toInt()
+                        val value = NyanNyanRank(
+                            name = (it.value as Map<*, *>)["nam"].toString(),
+                            point = (it.value as Map<*, *>)["pt"].toString().toInt()
+                        )
+                        ranks[key] = value
+                    }
+                _nyanNyanConfigEvent.postValue(NyanNyanConfig(nekosanPointMultiplier, ranks))
+            }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
@@ -2,15 +2,22 @@ package com.ntetz.android.nyannyanengine_android.model.dao.firebase
 
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
+import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
 
 interface IFirebaseClient {
+    fun initialize()
     fun logEvent(type: AnalyticsEvent, textParams: Map<String, String>?, numParams: Map<String, Int>?)
 }
 
 class FirebaseClient : IFirebaseClient {
     private val analytics = Firebase.analytics
+    private val auth = Firebase.auth
+
+    override fun initialize() {
+        auth.signInAnonymously()
+    }
 
     override fun logEvent(type: AnalyticsEvent, textParams: Map<String, String>?, numParams: Map<String, Int>?) {
         analytics.logEvent(type.title) {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
@@ -63,8 +63,10 @@ class FirebaseClient : IFirebaseClient {
         db.collection(usersCollectionName).document(twitterUserRecord.sealedUserId)
             .get()
             .addOnSuccessListener {
-                val nekosanPoint = (it.data?.get("np") as? Long)?.toInt() ?: return@addOnSuccessListener
-                val tweetCount = (it.data?.get("tc") as? Long)?.toInt() ?: return@addOnSuccessListener
+                val data = it.data ?: return@addOnSuccessListener createNyanNyanUser(twitterUserRecord)
+
+                val nekosanPoint = (data["np"] as? Long)?.toInt() ?: return@addOnSuccessListener
+                val tweetCount = (data["tc"] as? Long)?.toInt() ?: return@addOnSuccessListener
                 _nyanNyanUserEvent.postValue(
                     NyanNyanUser(id = it.id, nekosanPoint = nekosanPoint, tweetCount = tweetCount)
                 )
@@ -89,6 +91,19 @@ class FirebaseClient : IFirebaseClient {
                         ranks[key] = value
                     }
                 _nyanNyanConfigEvent.postValue(NyanNyanConfig(nekosanPointMultiplier, ranks))
+            }
+    }
+
+    private fun createNyanNyanUser(user: TwitterUserRecord) {
+        val userDocument = hashMapOf("np" to 0, "tc" to 0)
+        db.collection(usersCollectionName)
+            .document(user.sealedUserId)
+            .set(userDocument)
+            .addOnCompleteListener {
+                println("nyaoo--n ${NyanNyanUser(id = user.sealedUserId, nekosanPoint = 0, tweetCount = 0)}")
+                _nyanNyanUserEvent.postValue(
+                    NyanNyanUser(id = user.sealedUserId, nekosanPoint = 0, tweetCount = 0)
+                )
             }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/firebase/FirebaseClient.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
 import com.ntetz.android.nyannyanengine_android.model.config.DefaultUserConfig
@@ -23,6 +24,7 @@ interface IFirebaseClient {
     fun initialize()
     fun logEvent(type: AnalyticsEvent, textParams: Map<String, String>?, numParams: Map<String, Int>?)
     fun fetchNyanNyanUser(twitterUserRecord: TwitterUserRecord?)
+    fun incrementNyanNyanUser(key: String, value: Int, twitterUserRecord: TwitterUserRecord)
     fun fetchNyanNyanConfig()
 }
 
@@ -71,6 +73,11 @@ class FirebaseClient : IFirebaseClient {
                     NyanNyanUser(id = it.id, nekosanPoint = nekosanPoint, tweetCount = tweetCount)
                 )
             }
+    }
+
+    override fun incrementNyanNyanUser(key: String, value: Int, twitterUserRecord: TwitterUserRecord) {
+        db.collection(usersCollectionName).document(twitterUserRecord.sealedUserId)
+            .update(key, FieldValue.increment(value.toLong()))
     }
 
     override fun fetchNyanNyanConfig() {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/AnalyticsEvent.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/AnalyticsEvent.kt
@@ -1,3 +1,17 @@
 package com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase
 
-enum class AnalyticsEvent(val title: String)
+enum class AnalyticsEvent(val title: String) {
+    TAP_POST_NEKOGO("tap__post_nekogo"),
+    COMPLETE_POST_NEKOGO("complete__post_nekogo"),
+
+    TAP_SIGN_IN("tap__sign_in"),
+    COMPLETE_SIGN_IN("complete__sign_in"),
+
+    TAP_SIGN_OUT("tap__sign_out"),
+    COMPLETE_SIGN_OUT("complete__sign_out"),
+
+    TAP_SETTING_HASHTAG("tap__setting_hashtag"),
+    COMPLETE_SETTING_HASHTAG("complete__setting_hashtag"),
+
+    TAP_TWEET("tap__tweet"),
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/AnalyticsEvent.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/AnalyticsEvent.kt
@@ -1,0 +1,3 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase
+
+enum class AnalyticsEvent(val title: String)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/NyanNyanConfig.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/NyanNyanConfig.kt
@@ -1,0 +1,6 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase
+
+data class NyanNyanConfig(
+    val nekosanPointMultiplier: Int,
+    val ranks: Map<Int, NyanNyanRank>
+)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/NyanNyanRank.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/NyanNyanRank.kt
@@ -1,0 +1,6 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase
+
+data class NyanNyanRank(
+    val name: String,
+    val point: Int
+)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/NyanNyanUser.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/firebase/NyanNyanUser.kt
@@ -1,0 +1,7 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase
+
+data class NyanNyanUser(
+    val id: String,
+    val nekosanPoint: Int,
+    val tweetCount: Int
+)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/retrofit/Tweet.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/retrofit/Tweet.kt
@@ -14,4 +14,6 @@ data class Tweet(
 ) {
     val isError: Boolean
         get() = id.toInt() == 28
+
+    var point: Int = 0
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/TwitterUserRecord.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/TwitterUserRecord.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.IAccessToken
+import java.security.MessageDigest
 
 @Entity(tableName = "twitter_users")
 data class TwitterUserRecord(
@@ -13,4 +14,17 @@ data class TwitterUserRecord(
     @ColumnInfo(name = "screen_name") val screenName: String,
     @ColumnInfo(name = "name") val name: String,
     @ColumnInfo(name = "profile_image_url_https") val profileImageUrlHttps: String?
-) : IAccessToken
+) : IAccessToken {
+    val sealedUserId: String
+        get() = id.toMD5()
+
+    private fun String.toMD5(): String {
+        val digest = MessageDigest.getInstance("MD5").also { it.update(this.toByteArray()) }
+        val messageDigest = digest.digest()
+        return messageDigest.fold(initial = StringBuilder()) { result, current ->
+            var h = Integer.toHexString(0xFF and current.toInt())
+            while (h.length < 2) h = "0$h"
+            result.also { it.append(h) }
+        }.toString()
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/account/NyanNyanUserComponent.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/account/NyanNyanUserComponent.kt
@@ -1,0 +1,32 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.usecase.account
+
+import android.content.Context
+import com.ntetz.android.nyannyanengine_android.R
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanUser
+
+data class NyanNyanUserComponent(
+    val nyanNyanUser: NyanNyanUser,
+    private val nyanNyanConfig: NyanNyanConfig
+) {
+    fun getCurrentRank(context: Context): String? {
+        nyanNyanConfig.ranks.keys.sortedByDescending { it }.forEach {
+            val required = nyanNyanConfig.ranks[it]?.point ?: return null
+            if ((nyanNyanUser.nekosanPoint) >= required) {
+                return nyanNyanConfig.ranks[it]?.name
+            }
+        }
+        return context.getString(R.string.settings_lowest_rank)
+    }
+
+    val currentExtends: Int?
+        get() {
+            nyanNyanConfig.ranks.keys.sortedBy { it }.forEach {
+                val required = nyanNyanConfig.ranks[it]?.point ?: return null
+                if (nyanNyanUser.nekosanPoint < required) {
+                    return required - nyanNyanUser.nekosanPoint
+                }
+            }
+            return 99999
+        }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/hashtag/DefaultHashTagComponent.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/hashtag/DefaultHashTagComponent.kt
@@ -3,5 +3,6 @@ package com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag
 data class DefaultHashTagComponent(
     val id: Int,
     val textBody: String,
+    val nekosanPoint: Int = 0,
     val isEnabled: Boolean
 )

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/screen_transition/UserAction.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/usecase/screen_transition/UserAction.kt
@@ -1,0 +1,9 @@
+package com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition
+
+enum class UserAction {
+    POST_NEKOGO,
+    SIGN_IN,
+    SIGN_OUT,
+    TWEET,
+    SETTING_HASH_TAG,
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
@@ -39,6 +39,8 @@ interface IAccountRepository {
 
     suspend fun fetchNyanNyanConfig()
     suspend fun fetchNyanNyanUser(twitterUser: TwitterUserRecord?)
+    suspend fun incrementNekosanPoint(value: Int, twitterUser: TwitterUserRecord)
+    suspend fun incrementTweetCount(twitterUser: TwitterUserRecord)
 }
 
 class AccountRepository(
@@ -135,6 +137,14 @@ class AccountRepository(
 
     override suspend fun fetchNyanNyanUser(twitterUser: TwitterUserRecord?) {
         firebaseClient.fetchNyanNyanUser(twitterUser)
+    }
+
+    override suspend fun incrementNekosanPoint(value: Int, twitterUser: TwitterUserRecord) {
+        firebaseClient.incrementNyanNyanUser("np", value, twitterUser)
+    }
+
+    override suspend fun incrementTweetCount(twitterUser: TwitterUserRecord) {
+        firebaseClient.incrementNyanNyanUser("tc", 1, twitterUser)
     }
 
     private suspend fun invalidateAccessToken(

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepository.kt
@@ -1,12 +1,16 @@
 package com.ntetz.android.nyannyanengine_android.model.repository
 
 import android.net.Uri
+import androidx.lifecycle.LiveData
 import com.ntetz.android.nyannyanengine_android.model.config.DefaultUserConfig
 import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterConfig
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.IFirebaseClient
 import com.ntetz.android.nyannyanengine_android.model.dao.retrofit.ITwitterApi
 import com.ntetz.android.nyannyanengine_android.model.dao.room.ITwitterUserDao
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanUser
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.AccessToken
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.AccessTokenInvalidation
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.IAccessToken
@@ -23,20 +27,30 @@ import kotlinx.coroutines.withContext
 import retrofit2.Response
 
 interface IAccountRepository {
+    val nyanNyanConfigEvent: LiveData<NyanNyanConfig?>
+    val nyanNyanUserEvent: LiveData<NyanNyanUser?>
+
     suspend fun getAuthorizationToken(scope: CoroutineScope): String?
     suspend fun getAccessToken(oauthVerifier: String, oauthToken: String, scope: CoroutineScope): AccessToken
     suspend fun verifyAccessToken(token: IAccessToken, scope: CoroutineScope): User
     suspend fun loadTwitterUser(scope: CoroutineScope): TwitterUserRecord?
     suspend fun saveTwitterUser(record: TwitterUserRecord, scope: CoroutineScope)
     suspend fun deleteTwitterUser(token: IAccessToken, scope: CoroutineScope): AccessTokenInvalidation?
+
+    suspend fun fetchNyanNyanConfig()
+    suspend fun fetchNyanNyanUser(twitterUser: TwitterUserRecord?)
 }
 
 class AccountRepository(
     private val twitterApi: ITwitterApi,
     private val twitterConfig: ITwitterConfig = TwitterConfig(),
     private val base64Encoder: IBase64Encoder = Base64Encoder(),
-    private val twitterUserDao: ITwitterUserDao
+    private val twitterUserDao: ITwitterUserDao,
+    private val firebaseClient: IFirebaseClient
 ) : IAccountRepository {
+    override val nyanNyanConfigEvent = firebaseClient.nyanNyanConfigEvent
+    override val nyanNyanUserEvent = firebaseClient.nyanNyanUserEvent
+
     override suspend fun getAuthorizationToken(scope: CoroutineScope): String? {
         val additionalHeaders = listOf(
             TwitterSignParam(TwitterEndpoints.requestTokenOauthCallbackParamName, twitterConfig.callbackUrl)
@@ -113,6 +127,14 @@ class AccountRepository(
     override suspend fun deleteTwitterUser(token: IAccessToken, scope: CoroutineScope): AccessTokenInvalidation? {
         deleteTwitterUserRecord(scope)
         return invalidateAccessToken(token, scope)
+    }
+
+    override suspend fun fetchNyanNyanConfig() {
+        firebaseClient.fetchNyanNyanConfig()
+    }
+
+    override suspend fun fetchNyanNyanUser(twitterUser: TwitterUserRecord?) {
+        firebaseClient.fetchNyanNyanUser(twitterUser)
     }
 
     private suspend fun invalidateAccessToken(

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepository.kt
@@ -25,6 +25,7 @@ class HashtagsRepository(
             DefaultHashTagComponent(
                 it.id,
                 context.getString(defaultHashtagConfig.getTextBodyId(it.id) ?: return emptyList()),
+                defaultHashtagConfig.getNekosanPoint(it.id) ?: 0,
                 it.enabled
             )
         }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepository.kt
@@ -1,26 +1,32 @@
 package com.ntetz.android.nyannyanengine_android.model.repository
 
+import android.content.Context
+import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
 import com.ntetz.android.nyannyanengine_android.model.dao.room.IDefaultHashtagsDao
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHashtagRecord
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 interface IHashtagsRepository {
-    suspend fun getDefaultHashtagRecords(scope: CoroutineScope): List<DefaultHashtagRecord>
+    suspend fun getDefaultHashtags(scope: CoroutineScope, context: Context): List<DefaultHashTagComponent>
     fun updateDefaultHashtagRecord(record: DefaultHashtagRecord, scope: CoroutineScope)
 }
 
 class HashtagsRepository(
+    private val defaultHashtagConfig: IDefaultHashtagConfig,
     private val defaultHashtagsDao: IDefaultHashtagsDao
 ) : IHashtagsRepository {
 
-    override suspend fun getDefaultHashtagRecords(scope: CoroutineScope): List<DefaultHashtagRecord> {
-        return withContext(scope.coroutineContext) {
-            withContext(Dispatchers.IO) {
-                defaultHashtagsDao.getAll()
-            }
+    override suspend fun getDefaultHashtags(scope: CoroutineScope, context: Context): List<DefaultHashTagComponent> {
+        return getDefaultHashtagRecords(scope).map {
+            DefaultHashTagComponent(
+                it.id,
+                context.getString(defaultHashtagConfig.getTextBodyId(it.id) ?: return emptyList()),
+                it.enabled
+            )
         }
     }
 
@@ -28,6 +34,14 @@ class HashtagsRepository(
         scope.launch {
             withContext(Dispatchers.IO) {
                 defaultHashtagsDao.updateOne(record)
+            }
+        }
+    }
+
+    private suspend fun getDefaultHashtagRecords(scope: CoroutineScope): List<DefaultHashtagRecord> {
+        return withContext(scope.coroutineContext) {
+            withContext(Dispatchers.IO) {
+                defaultHashtagsDao.getAll()
             }
         }
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/MetricsRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/MetricsRepository.kt
@@ -1,0 +1,34 @@
+package com.ntetz.android.nyannyanengine_android.model.repository
+
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.IFirebaseClient
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+interface IMetricsRepository {
+    suspend fun logEvent(
+        type: AnalyticsEvent,
+        textParams: Map<String, String>? = null,
+        numParams: Map<String, Int>? = null,
+        scope: CoroutineScope
+    )
+}
+
+class MetricsRepository(
+    private val firebaseClient: IFirebaseClient
+) : IMetricsRepository {
+    override suspend fun logEvent(
+        type: AnalyticsEvent,
+        textParams: Map<String, String>?,
+        numParams: Map<String, Int>?,
+        scope: CoroutineScope
+    ) {
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                firebaseClient.logEvent(type, textParams, numParams)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepository.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepository.kt
@@ -20,7 +20,7 @@ import retrofit2.Response
 interface ITweetsRepository {
     suspend fun getLatestTweets(token: IAccessToken, scope: CoroutineScope): List<Tweet>
     suspend fun getPreviousTweets(maxId: Long, token: IAccessToken, scope: CoroutineScope): List<Tweet>
-    suspend fun postTweet(tweetBody: String, token: IAccessToken, scope: CoroutineScope): Tweet
+    suspend fun postTweet(tweetBody: String, point: Int, token: IAccessToken, scope: CoroutineScope): Tweet
 }
 
 class TweetsRepository(
@@ -80,7 +80,7 @@ class TweetsRepository(
         return body
     }
 
-    override suspend fun postTweet(tweetBody: String, token: IAccessToken, scope: CoroutineScope): Tweet {
+    override suspend fun postTweet(tweetBody: String, point: Int, token: IAccessToken, scope: CoroutineScope): Tweet {
         val additionalHeaders = listOf(
             TwitterSignParam(
                 TwitterEndpoints.postTweetStatusParamName,
@@ -106,7 +106,7 @@ class TweetsRepository(
         if (!result.isSuccessful || body == null) {
             return getErrorTweet(result)
         }
-        return body
+        return body.also { it.point = point }
     }
 
     private suspend fun getLatestTweetsFromWeb(

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/AccountUsecase.kt
@@ -1,16 +1,23 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
 import android.net.Uri
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Transformations
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.AccessToken
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.AccessTokenInvalidation
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.User
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.NyanNyanUserComponent
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IAccountRepository
 import kotlinx.coroutines.CoroutineScope
 
 interface IAccountUsecase {
+    val nyanNyanUserEvent: LiveData<NyanNyanUserComponent?>
+    val nyanNyanConfigEvent: LiveData<NyanNyanConfig?>
+
     suspend fun createAuthorizationEndpoint(scope: CoroutineScope): Uri?
     suspend fun fetchAccessToken(
         oauthVerifier: String,
@@ -20,9 +27,20 @@ interface IAccountUsecase {
 
     suspend fun loadAccessToken(scope: CoroutineScope): TwitterUserRecord?
     suspend fun deleteAccessToken(scope: CoroutineScope): AccessTokenInvalidation?
+
+    suspend fun fetchNyanNyanConfig()
+    suspend fun fetchNyanNyanUser(twitterUser: TwitterUserRecord?)
 }
 
 class AccountUsecase(private val accountRepository: IAccountRepository) : IAccountUsecase {
+    override val nyanNyanConfigEvent = accountRepository.nyanNyanConfigEvent
+    override val nyanNyanUserEvent = Transformations.map(accountRepository.nyanNyanUserEvent) {
+        NyanNyanUserComponent(
+            nyanNyanUser = it ?: return@map null,
+            nyanNyanConfig = nyanNyanConfigEvent.value ?: return@map null
+        )
+    }
+
     override suspend fun createAuthorizationEndpoint(scope: CoroutineScope): Uri? {
         val urlStr = listOf(
             TwitterEndpoints.baseEndpoint,
@@ -71,6 +89,14 @@ class AccountUsecase(private val accountRepository: IAccountRepository) : IAccou
     override suspend fun deleteAccessToken(scope: CoroutineScope): AccessTokenInvalidation? {
         val user = accountRepository.loadTwitterUser(scope) ?: return null
         return accountRepository.deleteTwitterUser(user, scope)
+    }
+
+    override suspend fun fetchNyanNyanConfig() {
+        accountRepository.fetchNyanNyanConfig()
+    }
+
+    override suspend fun fetchNyanNyanUser(twitterUser: TwitterUserRecord?) {
+        accountRepository.fetchNyanNyanUser(twitterUser)
     }
 
     private fun createTwitterUserRecord(tokenApiResponse: AccessToken, verifyApiResult: User): TwitterUserRecord? {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/ApplicationUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/ApplicationUsecase.kt
@@ -1,13 +1,18 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.IFirebaseClient
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.IUserProfileDatabase
 
 interface IApplicationUsecase {
     fun launch()
 }
 
-class ApplicationUsecase(private val userProfileDatabase: IUserProfileDatabase) : IApplicationUsecase {
+class ApplicationUsecase(
+    private val userProfileDatabase: IUserProfileDatabase,
+    private val firebaseClient: IFirebaseClient
+) : IApplicationUsecase {
     override fun launch() {
         userProfileDatabase.initialize()
+        firebaseClient.initialize()
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecase.kt
@@ -1,7 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
 import android.content.Context
-import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHashtagRecord
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IHashtagsRepository
@@ -14,23 +13,14 @@ interface IHashtagUsecase {
 
 class HashtagUsecase(
     private val hashtagsRepository: IHashtagsRepository,
-    private val defaultHashtagConfig: IDefaultHashtagConfig,
     private val context: Context
 ) : IHashtagUsecase {
     override suspend fun getDefaultHashtags(scope: CoroutineScope): List<DefaultHashTagComponent> {
-        return hashtagsRepository.getDefaultHashtagRecords(scope).mapNotNull { createDefaultHashtagComponent(it) }
+        return hashtagsRepository.getDefaultHashtags(scope, context)
     }
 
     override fun updateDefaultHashtag(component: DefaultHashTagComponent, scope: CoroutineScope) {
         hashtagsRepository.updateDefaultHashtagRecord(createDefaultHashtagRecord(component), scope)
-    }
-
-    private fun createDefaultHashtagComponent(record: DefaultHashtagRecord): DefaultHashTagComponent? {
-        return DefaultHashTagComponent(
-            id = record.id,
-            textBody = context.getString(defaultHashtagConfig.getTextBodyId(record.id) ?: return null),
-            isEnabled = record.enabled
-        )
     }
 
     private fun createDefaultHashtagRecord(component: DefaultHashTagComponent): DefaultHashtagRecord {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
@@ -38,7 +38,7 @@ class TweetsUsecase(
 
         accountRepository.incrementNekosanPoint(totalPoint, user)
         accountRepository.incrementTweetCount(user)
-        return tweetsRepository.postTweet(getTweetBodyWithHashtags(tweetBody, hashtags), user, scope)
+        return tweetsRepository.postTweet(getTweetBodyWithHashtags(tweetBody, hashtags), totalPoint, user, scope)
     }
 
     private fun getTweetBodyWithHashtags(tweetBody: String, hashtags: List<DefaultHashTagComponent>): String {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
@@ -28,6 +28,8 @@ class TweetsUsecase(
 
     override suspend fun postTweet(tweetBody: String, scope: CoroutineScope): Tweet {
         val user = accountRepository.loadTwitterUser(scope) ?: return DefaultTweetConfig.notSignInlist[0]
+        accountRepository.incrementNekosanPoint(30, user)
+        accountRepository.incrementTweetCount(user)
         return tweetsRepository.postTweet(tweetBody, user, scope)
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
@@ -1,8 +1,11 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
+import android.content.Context
 import com.ntetz.android.nyannyanengine_android.model.config.DefaultTweetConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IAccountRepository
+import com.ntetz.android.nyannyanengine_android.model.repository.IHashtagsRepository
 import com.ntetz.android.nyannyanengine_android.model.repository.ITweetsRepository
 import com.ntetz.android.nyannyanengine_android.util.nekosanPoint
 import kotlinx.coroutines.CoroutineScope
@@ -10,12 +13,13 @@ import kotlinx.coroutines.CoroutineScope
 interface ITweetsUsecase {
     suspend fun getLatestTweets(scope: CoroutineScope): List<Tweet>
     suspend fun getPreviousTweets(maxId: Long, scope: CoroutineScope): List<Tweet>
-    suspend fun postTweet(tweetBody: String, scope: CoroutineScope): Tweet
+    suspend fun postTweet(tweetBody: String, scope: CoroutineScope, context: Context): Tweet
 }
 
 class TweetsUsecase(
     private val tweetsRepository: ITweetsRepository,
-    private val accountRepository: IAccountRepository
+    private val accountRepository: IAccountRepository,
+    private val hashtagsRepository: IHashtagsRepository
 ) : ITweetsUsecase {
     override suspend fun getLatestTweets(scope: CoroutineScope): List<Tweet> {
         val user = accountRepository.loadTwitterUser(scope) ?: return DefaultTweetConfig.notSignInlist
@@ -27,13 +31,20 @@ class TweetsUsecase(
         return tweetsRepository.getPreviousTweets(maxId = maxId, token = user, scope = scope)
     }
 
-    override suspend fun postTweet(tweetBody: String, scope: CoroutineScope): Tweet {
+    override suspend fun postTweet(tweetBody: String, scope: CoroutineScope, context: Context): Tweet {
         val user = accountRepository.loadTwitterUser(scope) ?: return DefaultTweetConfig.notSignInlist[0]
+        val hashtags = hashtagsRepository.getDefaultHashtags(scope, context)
 
         val multipliter = accountRepository.nyanNyanConfigEvent.value?.nekosanPointMultiplier ?: 1
         val rawPoint = tweetBody.nekosanPoint()
         accountRepository.incrementNekosanPoint(rawPoint * multipliter, user)
         accountRepository.incrementTweetCount(user)
-        return tweetsRepository.postTweet(tweetBody, user, scope)
+        return tweetsRepository.postTweet(getTweetBodyWithHashtags(tweetBody, hashtags), user, scope)
+    }
+
+    private fun getTweetBodyWithHashtags(tweetBody: String, hashtags: List<DefaultHashTagComponent>): String {
+        return hashtags.filter { it.isEnabled }.fold(tweetBody) { result, current ->
+            listOf(result, current.textBody).joinToString("\n")
+        }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
@@ -4,6 +4,7 @@ import com.ntetz.android.nyannyanengine_android.model.config.DefaultTweetConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.repository.IAccountRepository
 import com.ntetz.android.nyannyanengine_android.model.repository.ITweetsRepository
+import com.ntetz.android.nyannyanengine_android.util.nekosanPoint
 import kotlinx.coroutines.CoroutineScope
 
 interface ITweetsUsecase {
@@ -28,7 +29,10 @@ class TweetsUsecase(
 
     override suspend fun postTweet(tweetBody: String, scope: CoroutineScope): Tweet {
         val user = accountRepository.loadTwitterUser(scope) ?: return DefaultTweetConfig.notSignInlist[0]
-        accountRepository.incrementNekosanPoint(30, user)
+
+        val multipliter = accountRepository.nyanNyanConfigEvent.value?.nekosanPointMultiplier ?: 1
+        val rawPoint = tweetBody.nekosanPoint()
+        accountRepository.incrementNekosanPoint(rawPoint * multipliter, user)
         accountRepository.incrementTweetCount(user)
         return tweetsRepository.postTweet(tweetBody, user, scope)
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/UserActionUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/UserActionUsecase.kt
@@ -1,0 +1,66 @@
+package com.ntetz.android.nyannyanengine_android.model.usecase
+
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
+import com.ntetz.android.nyannyanengine_android.model.repository.IMetricsRepository
+import kotlinx.coroutines.CoroutineScope
+
+interface IUserActionUsecase {
+    suspend fun tap(
+        userAction: UserAction,
+        textParams: Map<String, String>? = null,
+        numParams: Map<String, Int>? = null,
+        scope: CoroutineScope
+    )
+
+    suspend fun complete(
+        userAction: UserAction,
+        textParams: Map<String, String>? = null,
+        numParams: Map<String, Int>? = null,
+        scope: CoroutineScope
+    )
+}
+
+class UserActionUsecase(private val metricsRepository: IMetricsRepository) : IUserActionUsecase {
+    override suspend fun tap(
+        userAction: UserAction,
+        textParams: Map<String, String>?,
+        numParams: Map<String, Int>?,
+        scope: CoroutineScope
+    ) {
+        val eventType = when (userAction) {
+            UserAction.POST_NEKOGO -> AnalyticsEvent.TAP_POST_NEKOGO
+            UserAction.SIGN_IN -> AnalyticsEvent.TAP_SIGN_IN
+            UserAction.SIGN_OUT -> AnalyticsEvent.TAP_SIGN_OUT
+            UserAction.SETTING_HASH_TAG -> AnalyticsEvent.TAP_SETTING_HASHTAG
+            UserAction.TWEET -> AnalyticsEvent.TAP_TWEET
+        }
+        metricsRepository.logEvent(
+            type = eventType,
+            textParams = textParams,
+            numParams = numParams,
+            scope = scope
+        )
+    }
+
+    override suspend fun complete(
+        userAction: UserAction,
+        textParams: Map<String, String>?,
+        numParams: Map<String, Int>?,
+        scope: CoroutineScope
+    ) {
+        val eventType = when (userAction) {
+            UserAction.POST_NEKOGO -> AnalyticsEvent.COMPLETE_POST_NEKOGO
+            UserAction.SIGN_IN -> AnalyticsEvent.COMPLETE_SIGN_IN
+            UserAction.SIGN_OUT -> AnalyticsEvent.COMPLETE_SIGN_OUT
+            UserAction.SETTING_HASH_TAG -> AnalyticsEvent.COMPLETE_SETTING_HASHTAG
+            UserAction.TWEET -> return
+        }
+        metricsRepository.logEvent(
+            type = eventType,
+            textParams = textParams,
+            numParams = numParams,
+            scope = scope
+        )
+    }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainAdapter.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainAdapter.kt
@@ -8,11 +8,12 @@ import androidx.recyclerview.widget.DiffUtil
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 
 class MainAdapter(
+    private val viewModel: MainViewModel,
     private val context: Context?,
     private val parentLifecycleOwner: LifecycleOwner
 ) : PagingDataAdapter<Tweet, MainViewHolder>(REPO_COMPARATOR) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MainViewHolder {
-        return MainViewHolder.create(context, parent)
+        return MainViewHolder.create(viewModel, context, parent)
     }
 
     override fun onBindViewHolder(holder: MainViewHolder, position: Int) {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -23,7 +23,7 @@ class MainFragment : Fragment() {
 
     private val viewModel: MainViewModel by viewModel()
     private lateinit var binding: MainFragmentBinding
-    private val adapter: MainAdapter by lazy { MainAdapter(this.context, this) }
+    private val adapter: MainAdapter by lazy { MainAdapter(viewModel, this.context, this) }
     private var searchJob: Job? = null
 
     override fun onCreateView(
@@ -46,6 +46,7 @@ class MainFragment : Fragment() {
             binding.tweetListFrame.isRefreshing = false
         }
         binding.postNekogoFragmentOpenButton.setOnClickListener {
+            viewModel.logOpenPostNekogoScreen()
             findNavController().navigate(R.id.action_mainFragment_to_postNekogoFragment)
         }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -53,6 +53,13 @@ class MainFragment : Fragment() {
         viewModel.userInfoEvent.observe(viewLifecycleOwner, {
             (activity as? MainActivity)?.updateUserInfo(it)
         })
+        viewModel.nyanNyanConfigEvent.observe(viewLifecycleOwner, {
+            viewModel.loadNyanNyanUserInfo()
+        })
+        viewModel.nyanNyanUserEvent.observe(viewLifecycleOwner, {
+            // Firestoreからいい感じで同期的に取得できる処理があれば、configとuserの取得処理に2つのLiveDataを使わなくてすみそう。
+            (activity as? MainActivity)?.updateNyanNyanUserInfo(it)
+        })
         viewModel.loadUserInfo()
         setupAdapter()
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -12,6 +12,7 @@ import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.util.toNyanNyan
 
 class MainViewHolder(
+    private val viewModel: MainViewModel,
     private val context: Context?,
     private val binding: MainCellBinding
 ) : RecyclerView.ViewHolder(binding.root) {
@@ -19,6 +20,7 @@ class MainViewHolder(
         val context = context ?: return
         binding.root.setOnClickListener {
             binding.isNyanNyan = !(binding.isNyanNyan as Boolean)
+            viewModel.logToggleTweet(bindingAdapterPosition, (binding.isNyanNyan as Boolean))
         }
         binding.isNyanNyan = !item.isError
         binding.nyanNyanTweetTextBody = item.text.toNyanNyan(context)
@@ -27,7 +29,8 @@ class MainViewHolder(
     }
 
     companion object {
-        fun create(context: Context?, parent: ViewGroup) = MainViewHolder(
+        fun create(viewModel: MainViewModel, context: Context?, parent: ViewGroup) = MainViewHolder(
+            viewModel,
             context,
             DataBindingUtil.inflate<MainCellBinding>(
                 LayoutInflater.from(parent.context),

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
@@ -9,8 +9,10 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.NyanNyanUserComponent
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
@@ -27,6 +29,10 @@ class MainViewModel(
     val userInfoEvent: LiveData<TwitterUserRecord?>
         get() = _userInfoEvent
 
+    val nyanNyanUserEvent: LiveData<NyanNyanUserComponent?> =
+        accountUsecase.nyanNyanUserEvent
+    val nyanNyanConfigEvent: LiveData<NyanNyanConfig?> = accountUsecase.nyanNyanConfigEvent
+
     val tweetStream: Flow<PagingData<Tweet>> = Pager(
         config = PagingConfig(
             pageSize = TwitterEndpoints.homeTimelineCountParamDefaultValue.toInt(),
@@ -38,6 +44,13 @@ class MainViewModel(
     fun loadUserInfo() {
         viewModelScope.launch {
             _userInfoEvent.postValue(accountUsecase.loadAccessToken(this))
+            accountUsecase.fetchNyanNyanConfig()
+        }
+    }
+
+    fun loadNyanNyanUserInfo() {
+        viewModelScope.launch {
+            accountUsecase.fetchNyanNyanUser(accountUsecase.loadAccessToken(this))
         }
     }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
@@ -11,14 +11,17 @@ import androidx.paging.cachedIn
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 class MainViewModel(
     private val accountUsecase: IAccountUsecase,
-    private val tweetsUsecase: ITweetsUsecase
+    private val tweetsUsecase: ITweetsUsecase,
+    private val userActionUsecase: IUserActionUsecase
 ) : ViewModel() {
     private val _userInfoEvent: MutableLiveData<TwitterUserRecord?> = MutableLiveData()
     val userInfoEvent: LiveData<TwitterUserRecord?>
@@ -35,6 +38,30 @@ class MainViewModel(
     fun loadUserInfo() {
         viewModelScope.launch {
             _userInfoEvent.postValue(accountUsecase.loadAccessToken(this))
+        }
+    }
+
+    fun logOpenPostNekogoScreen() {
+        viewModelScope.launch {
+            userActionUsecase.tap(
+                userAction = UserAction.POST_NEKOGO,
+                textParams = mapOf("is_signed_in" to (_userInfoEvent.value != null).toString()),
+                scope = this
+            )
+        }
+    }
+
+    fun logToggleTweet(position: Int, toNekogo: Boolean) {
+        viewModelScope.launch {
+            userActionUsecase.tap(
+                userAction = UserAction.TWEET,
+                textParams = mapOf(
+                    "is_signed_in" to (_userInfoEvent.value != null).toString(),
+                    "to_nekogo" to toNekogo.toString()
+                ),
+                numParams = mapOf("position" to position),
+                scope = this
+            )
         }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoFragment.kt
@@ -39,7 +39,17 @@ class PostNekogoFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         viewModel.postTweetEvent.observe(viewLifecycleOwner, {
-            Toast.makeText(context, "${it?.text}${context?.getString(R.string.post_result)}", Toast.LENGTH_SHORT).show()
+            val textBody = listOf(
+                it?.point,
+                context?.getString(R.string.post_point),
+                it?.text?.splitToSequence("\n")?.first(),
+                context?.getString(R.string.post_result)
+            ).joinToString("")
+            Toast.makeText(
+                context,
+                textBody,
+                Toast.LENGTH_SHORT
+            ).show()
             findNavController().navigate(R.id.action_postNekogoFragment_to_mainFragment)
         })
         viewModel.userInfoEvent.observe(viewLifecycleOwner, {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoFragment.kt
@@ -37,6 +37,10 @@ class PostNekogoFragment : Fragment() {
             Toast.makeText(context, "${it?.text}${context?.getString(R.string.post_result)}", Toast.LENGTH_SHORT).show()
             findNavController().navigate(R.id.action_postNekogoFragment_to_mainFragment)
         })
+        viewModel.userInfoEvent.observe(viewLifecycleOwner, {
+            binding.testButton.isEnabled = (it != null)
+        })
+        viewModel.loadUserInfo()
         super.onActivityCreated(savedInstanceState)
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoFragment.kt
@@ -27,7 +27,12 @@ class PostNekogoFragment : Fragment() {
     ): View? {
         binding = PostNekogoFragmentBinding.inflate(inflater, container, false)
         binding.inputText = context?.getString(R.string.post_input_original_text)
-        binding.testButton.setOnClickListener { viewModel.postNekogo(binding.nekogoResult.text.toString()) }
+        binding.testButton.setOnClickListener {
+            viewModel.postNekogo(
+                binding.nekogoResult.text.toString(),
+                context ?: return@setOnClickListener
+            )
+        }
         binding.lifecycleOwner = this
         return binding.root
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
@@ -5,13 +5,28 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
 import kotlinx.coroutines.launch
 
-class PostNekogoViewModel(private val tweetsUsecase: ITweetsUsecase) : ViewModel() {
+class PostNekogoViewModel(
+    private val accountUsecase: IAccountUsecase,
+    private val tweetsUsecase: ITweetsUsecase
+) : ViewModel() {
+    private val _userInfoEvent: MutableLiveData<TwitterUserRecord?> = MutableLiveData()
+    val userInfoEvent: LiveData<TwitterUserRecord?>
+        get() = _userInfoEvent
+
     private val _postTweetEvent: MutableLiveData<Tweet?> = MutableLiveData()
     val postTweetEvent: LiveData<Tweet?>
         get() = _postTweetEvent
+
+    fun loadUserInfo() {
+        viewModelScope.launch {
+            _userInfoEvent.postValue(accountUsecase.loadAccessToken(this))
+        }
+    }
 
     fun postNekogo(inputText: String) {
         viewModelScope.launch {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
@@ -6,13 +6,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.launch
 
 class PostNekogoViewModel(
     private val accountUsecase: IAccountUsecase,
-    private val tweetsUsecase: ITweetsUsecase
+    private val tweetsUsecase: ITweetsUsecase,
+    private val userActionUsecase: IUserActionUsecase
 ) : ViewModel() {
     private val _userInfoEvent: MutableLiveData<TwitterUserRecord?> = MutableLiveData()
     val userInfoEvent: LiveData<TwitterUserRecord?>
@@ -31,6 +34,11 @@ class PostNekogoViewModel(
     fun postNekogo(inputText: String) {
         viewModelScope.launch {
             _postTweetEvent.postValue(tweetsUsecase.postTweet(inputText, this))
+            userActionUsecase.complete(
+                userAction = UserAction.POST_NEKOGO,
+                textParams = mapOf("is_signed_in" to (_userInfoEvent.value != null).toString()),
+                scope = this
+            )
         }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.post_nekogo
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -31,9 +32,9 @@ class PostNekogoViewModel(
         }
     }
 
-    fun postNekogo(inputText: String) {
+    fun postNekogo(inputText: String, context: Context) {
         viewModelScope.launch {
-            _postTweetEvent.postValue(tweetsUsecase.postTweet(inputText, this))
+            _postTweetEvent.postValue(tweetsUsecase.postTweet(inputText, this, context))
             userActionUsecase.complete(
                 userAction = UserAction.POST_NEKOGO,
                 textParams = mapOf("is_signed_in" to (_userInfoEvent.value != null).toString()),

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
@@ -5,10 +5,15 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IHashtagUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.launch
 
-class HashtagSettingViewModel(private val hashtagUsecase: IHashtagUsecase) : ViewModel() {
+class HashtagSettingViewModel(
+    private val hashtagUsecase: IHashtagUsecase,
+    private val userActionUsecase: IUserActionUsecase
+) : ViewModel() {
     private val _defaultHashtagComponents: MutableLiveData<List<DefaultHashTagComponent>> = MutableLiveData(listOf())
     val defaultHashtagComponents: LiveData<List<DefaultHashTagComponent>>
         get() = _defaultHashtagComponents
@@ -21,5 +26,15 @@ class HashtagSettingViewModel(private val hashtagUsecase: IHashtagUsecase) : Vie
 
     fun updateDefaultHashtagComponent(defaultHashtagComponent: DefaultHashTagComponent) {
         hashtagUsecase.updateDefaultHashtag(defaultHashtagComponent, viewModelScope)
+        viewModelScope.launch {
+            userActionUsecase.complete(
+                userAction = UserAction.SETTING_HASH_TAG,
+                textParams = mapOf(
+                    "tag_body" to defaultHashtagComponent.textBody,
+                    "is_enabled" to defaultHashtagComponent.isEnabled.toString()
+                ),
+                scope = this
+            )
+        }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
@@ -5,10 +5,15 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.launch
 
-class SignInViewModel(private val accountUsecase: IAccountUsecase) : ViewModel() {
+class SignInViewModel(
+    private val accountUsecase: IAccountUsecase,
+    private val userActionUsecase: IUserActionUsecase
+) : ViewModel() {
     private val _signInEvent: MutableLiveData<SignInResultComponent?> = MutableLiveData()
     val signInEvent: LiveData<SignInResultComponent?>
         get() = _signInEvent
@@ -28,6 +33,7 @@ class SignInViewModel(private val accountUsecase: IAccountUsecase) : ViewModel()
                     scope = this
                 )
             )
+            userActionUsecase.complete(userAction = UserAction.SIGN_IN, scope = this)
         }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModel.kt
@@ -5,10 +5,15 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.AccessTokenInvalidation
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.launch
 
-class SignOutViewModel(private val accountUsecase: IAccountUsecase) : ViewModel() {
+class SignOutViewModel(
+    private val accountUsecase: IAccountUsecase,
+    private val userActionUsecase: IUserActionUsecase
+) : ViewModel() {
     private val _signOutEvent: MutableLiveData<AccessTokenInvalidation?> = MutableLiveData()
     val signOutEvent: LiveData<AccessTokenInvalidation?>
         get() = _signOutEvent
@@ -18,6 +23,7 @@ class SignOutViewModel(private val accountUsecase: IAccountUsecase) : ViewModel(
             _signOutEvent.postValue(
                 accountUsecase.deleteAccessToken(this)
             )
+            userActionUsecase.complete(userAction = UserAction.SIGN_OUT, scope = this)
         }
     }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/util/NekosanExtension.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/util/NekosanExtension.kt
@@ -45,6 +45,10 @@ fun String.isNekogo(context: Context): Boolean {
     return Regex(pattern).matches(this)
 }
 
+fun String.nekosanPoint(): Int {
+    return getNekosanPrefixPoint(this)
+}
+
 private fun getMD5(text: String): String {
     val digest = MessageDigest.getInstance("MD5").also { it.update(text.toByteArray()) }
     val messageDigest = digest.digest()
@@ -97,4 +101,35 @@ private fun getNekogoSuffixFragment(char: Char): String {
         'f' -> "XD"
         else -> "(^o^)"
     }
+}
+
+private fun getNekosanPrefixPoint(nekogoStr: String): Int {
+    if (nekogoStr.contains("🌈")) {
+        return 80
+    }
+    if (nekogoStr.contains("🐟")) {
+        return 80
+    }
+    if (nekogoStr.contains("😊")) {
+        return 80
+    }
+    if (nekogoStr.contains("🏆")) {
+        return 50
+    }
+    if (nekogoStr.contains("🎊")) {
+        return 50
+    }
+    if (nekogoStr.contains(":)")) {
+        return 30
+    }
+    if (nekogoStr.contains("XD")) {
+        return 30
+    }
+    if (nekogoStr.contains("🐤")) {
+        return 20
+    }
+    if (nekogoStr.contains("🙁")) {
+        return 20
+    }
+    return 10
 }

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -34,4 +34,17 @@
         android:text="@string/default_twitter_id"
         android:textAppearance="@style/TextAppearance.SelfTwitterId" />
 
+    <TextView
+        android:id="@+id/current_rank"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_teacher_rank"
+        android:textAppearance="@style/TextAppearance.SelfTwitterId" />
+
+    <TextView
+        android:id="@+id/current_extends"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_teacher_extends"
+        android:textAppearance="@style/TextAppearance.SelfTwitterId" />
 </LinearLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -11,6 +11,7 @@
 
     <string name="settings_title_hashtag_engine">#MeowMeowEngine</string>
     <string name="settings_title_hashtag_nadenade">#PetMeMeeow🧶</string>
+    <string name="settings_lowest_rank">Baby Nyan-nya</string>
 
     <string name="menu_hash_tag">Hash Tags</string>
     <string name="menu_sign_in">Sign in</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -6,6 +6,7 @@
     <string name="home_timeline_description_post_nekogo">Post cat language</string>
 
     <string name="post_input_original_text">This text is translated into cat lang. below, meeow.</string>
+    <string name="post_point"> point 😺💰 \n\n</string>
     <string name="post_button_name">Tweet as Cat</string>
     <string name="post_result">"\n is your cry, meeow."</string>
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -12,6 +12,8 @@
     <string name="settings_title_hashtag_engine">#MeowMeowEngine</string>
     <string name="settings_title_hashtag_nadenade">#PetMeMeeow🧶</string>
     <string name="settings_lowest_rank">Baby Nyan-nya</string>
+    <string name="settings_teacher_rank">Angel Nyan-nya</string>
+    <string name="settings_teacher_extends">0</string>
 
     <string name="menu_hash_tag">Hash Tags</string>
     <string name="menu_sign_in">Sign in</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,6 +11,7 @@
 
     <string name="settings_title_hashtag_engine">#にゃんにゃんエンジン</string>
     <string name="settings_title_hashtag_nadenade">#なでてほしいにゃ🧶</string>
+    <string name="settings_lowest_rank">幼にゃんにゃ</string>
 
     <string name="menu_hash_tag">はっしゅたぐ</string>
     <string name="menu_sign_in">ログインする</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -12,6 +12,8 @@
     <string name="settings_title_hashtag_engine">#にゃんにゃんエンジン</string>
     <string name="settings_title_hashtag_nadenade">#なでてほしいにゃ🧶</string>
     <string name="settings_lowest_rank">幼にゃんにゃ</string>
+    <string name="settings_teacher_rank">エンジェルにゃんにゃ</string>
+    <string name="settings_teacher_extends">0</string>
 
     <string name="menu_hash_tag">はっしゅたぐ</string>
     <string name="menu_sign_in">ログインする</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -7,6 +7,7 @@
 
     <string name="post_input_original_text">ここに文章を書くと、下でネコ語表示されるにゃ!</string>
     <string name="post_button_name">ネコ語でツイートする</string>
+    <string name="post_point"> ぽいんと😺💰 \n\n</string>
     <string name="post_result">\nってツイートしたにゃ</string>
 
     <string name="settings_title_hashtag_engine">#にゃんにゃんエンジン</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="settings_title_hashtag_engine">#MeowMeowEngine</string>
     <string name="settings_title_hashtag_nadenade">#PetMeMeeow🧶</string>
     <string name="settings_lowest_rank">Baby Nyan-nya</string>
+    <string name="settings_teacher_rank">Angel Nyan-nya</string>
+    <string name="settings_teacher_extends">0</string>
 
     <string name="menu_hash_tag">Hash Tags</string>
     <string name="menu_sign_in">Sign in</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="home_timeline_description_post_nekogo">Post cat language</string>
 
     <string name="post_input_original_text">This text is translated into cat lang. below, meeow.</string>
+    <string name="post_point"> point 😺💰 \n\n</string>
     <string name="post_button_name">Tweet as Cat</string>
     <string name="post_result">"\n is your cry, meeow."</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
 
     <string name="settings_title_hashtag_engine">#MeowMeowEngine</string>
     <string name="settings_title_hashtag_nadenade">#PetMeMeeow🧶</string>
+    <string name="settings_lowest_rank">Baby Nyan-nya</string>
 
     <string name="menu_hash_tag">Hash Tags</string>
     <string name="menu_sign_in">Sign in</string>

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultHashtagConfigTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultHashtagConfigTests.kt
@@ -34,6 +34,16 @@ class DefaultHashtagConfigTests {
     }
 
     @Test
+    fun getNekosanPoint_組み込まれたidに対して組み込まれた設定由来の値が取得できること() {
+        Truth.assertThat(DefaultHashtagConfig().getNekosanPoint(1)).isEqualTo(30)
+    }
+
+    @Test
+    fun getNekosanPoint_組み込まれていないidに対してnullが取得できること() {
+        Truth.assertThat(DefaultHashtagConfig().getNekosanPoint(-1)).isNull()
+    }
+
+    @Test
     fun populate_データベースが空の時登録処理が走ること() = runBlocking {
         val config = DefaultHashtagConfig()
         val firstEmbeddedRecord = config.getInitializationRecords()[0]

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/UserProfileDatabaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/room/UserProfileDatabaseTests.kt
@@ -46,7 +46,7 @@ class UserProfileDatabaseTests {
         `when`(mockDefaultHashtagConfig.populate(database.defaultHashtagsDao())).thenReturn(Unit)
 
         database.initialize()
-        delay(100) // これがないと、initialize内部のCoroutineの起動を見届けられない模様
+        delay(20) // これがないと、initialize内部のCoroutineの起動を見届けられない模様
         verify(mockDefaultHashtagConfig, times(1)).populate(database.defaultHashtagsDao())
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/AccountRepositoryTests.kt
@@ -274,4 +274,52 @@ class AccountRepositoryTests {
 
         Mockito.verify(mockFirebaseClient, Mockito.times(1)).fetchNyanNyanUser(mockTwitterUserRecord)
     }
+
+    @Test
+    fun incrementNekosanPoint_firebaseClientのincrementNyanNyanUserが1度実行されること() = runBlocking {
+        val mockTwitterUserRecord = TwitterUserRecord(
+            "id",
+            "testToken",
+            "testTokenSecret",
+            "testScName",
+            "testName",
+            "https://ntetz.com/test.jpg"
+        )
+        doNothing().`when`(mockFirebaseClient).incrementNyanNyanUser("np", 3, mockTwitterUserRecord)
+
+        AccountRepository(
+            twitterApi = mockTwitterApi,
+            twitterConfig = mockTwitterConfig,
+            base64Encoder = TestUtil.mockBase64Encoder,
+            twitterUserDao = mockTwitterUserDao,
+            firebaseClient = mockFirebaseClient
+        ).incrementNekosanPoint(3, mockTwitterUserRecord)
+        delay(20) // これがないと、initialize内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+
+        Mockito.verify(mockFirebaseClient, Mockito.times(1)).incrementNyanNyanUser("np", 3, mockTwitterUserRecord)
+    }
+
+    @Test
+    fun incrementTweetCount_firebaseClientのincrementNyanNyanUserが1度実行されること() = runBlocking {
+        val mockTwitterUserRecord = TwitterUserRecord(
+            "id",
+            "testToken",
+            "testTokenSecret",
+            "testScName",
+            "testName",
+            "https://ntetz.com/test.jpg"
+        )
+        doNothing().`when`(mockFirebaseClient).incrementNyanNyanUser("tc", 1, mockTwitterUserRecord)
+
+        AccountRepository(
+            twitterApi = mockTwitterApi,
+            twitterConfig = mockTwitterConfig,
+            base64Encoder = TestUtil.mockBase64Encoder,
+            twitterUserDao = mockTwitterUserDao,
+            firebaseClient = mockFirebaseClient
+        ).incrementTweetCount(mockTwitterUserRecord)
+        delay(20) // これがないと、initialize内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+
+        Mockito.verify(mockFirebaseClient, Mockito.times(1)).incrementNyanNyanUser("tc", 1, mockTwitterUserRecord)
+    }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/HashtagsRepositoryTests.kt
@@ -41,7 +41,7 @@ class HashtagsRepositoryTests {
                 this,
                 mockContext
             )
-        ).isEqualTo(listOf(DefaultHashTagComponent(9999, "testHashTaaag", true)))
+        ).isEqualTo(listOf(DefaultHashTagComponent(9999, "testHashTaaag", 0, true)))
     }
 
     @Test

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/MetricsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/MetricsRepositoryTests.kt
@@ -1,0 +1,40 @@
+package com.ntetz.android.nyannyanengine_android.model.repository
+
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.IFirebaseClient
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class MetricsRepositoryTests {
+    @Mock
+    private lateinit var mockFirebaseClient: IFirebaseClient
+
+    @Test
+    fun logEvent_firebaseClientのlogEventが一度呼ばれること() = runBlocking {
+        val testStrMap = mapOf("testStr" to "testStrval")
+        val testNumMap = mapOf("testInt" to 4)
+        doNothing().`when`(mockFirebaseClient)
+            .logEvent(AnalyticsEvent.TAP_TWEET, testStrMap, testNumMap)
+        MetricsRepository(mockFirebaseClient).logEvent(
+            AnalyticsEvent.TAP_TWEET,
+            testStrMap,
+            testNumMap,
+            this
+        )
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+
+        verify(mockFirebaseClient, times(1)).logEvent(
+            AnalyticsEvent.TAP_TWEET,
+            testStrMap,
+            testNumMap
+        )
+    }
+}

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepositoryTests.kt
@@ -212,6 +212,7 @@ class TweetsRepositoryTests {
             Truth.assertThat(
                 testRepository.postTweet(
                     tweetBody = "dummy",
+                    point = 300,
                     token = TwitterUserRecord(
                         "", "", "", "", "testName", null
                     ),
@@ -226,6 +227,42 @@ class TweetsRepositoryTests {
                         user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
                     )
                 )
+        }
+    }
+
+    @Test
+    fun postTweet_pointの値が反映された値が得られること() = runBlocking {
+        withContext(Dispatchers.IO) {
+            val mockEndpoints = TestUtil.mockNormalRetrofit
+                .create(ITwitterApiEndpoints::class.java)
+                .returningResponse(
+                    Tweet(
+                        id = 2828,
+                        text = "postTestTweeter!",
+                        createdAt = "3 gatsu 2 nichi",
+                        user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
+                    )
+                )
+            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+
+            `when`(mockTwitterConfig.apiSecret).thenReturn("")
+            `when`(mockTwitterConfig.consumerKey).thenReturn("")
+            val testRepository =
+                TweetsRepository(
+                    twitterApi = mockTwitterApi,
+                    twitterConfig = mockTwitterConfig,
+                    base64Encoder = TestUtil.mockBase64Encoder
+                )
+            Truth.assertThat(
+                testRepository.postTweet(
+                    tweetBody = "dummy",
+                    point = 300,
+                    token = TwitterUserRecord(
+                        "", "", "", "", "testName", null
+                    ),
+                    scope = this
+                ).point
+            ).isEqualTo(300)
         }
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/ApplicationUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/ApplicationUsecaseTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
+import com.ntetz.android.nyannyanengine_android.model.dao.firebase.IFirebaseClient
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.IUserProfileDatabase
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,11 +15,22 @@ class ApplicationUsecaseTests {
     @Mock
     private lateinit var mockUserProfileDatabase: IUserProfileDatabase
 
+    @Mock
+    private lateinit var mockFirebaseClient: IFirebaseClient
+
     @Test
     fun launch_userProfileDatabaseのinitializeが1度呼ばれること() {
         doNothing().`when`(mockUserProfileDatabase).initialize()
 
-        ApplicationUsecase(mockUserProfileDatabase).launch()
+        ApplicationUsecase(mockUserProfileDatabase, mockFirebaseClient).launch()
         verify(mockUserProfileDatabase, times(1)).initialize()
+    }
+
+    @Test
+    fun launch_firebaseClientのinitializeが1度呼ばれること() {
+        doNothing().`when`(mockFirebaseClient).initialize()
+
+        ApplicationUsecase(mockUserProfileDatabase, mockFirebaseClient).launch()
+        verify(mockFirebaseClient, times(1)).initialize()
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecaseTests.kt
@@ -26,7 +26,7 @@ class HashtagUsecaseTests {
     @Test
     fun getDefaultHashtags_レポジトリ由来の値が得られること() = runBlocking {
         `when`(mockHashtagRepository.getDefaultHashtags(this, mockContext)).thenReturn(
-            listOf(DefaultHashTagComponent(99999, "testHashtaaag", true))
+            listOf(DefaultHashTagComponent(99999, "testHashtaaag", 30, true))
         )
 
         Truth.assertThat(
@@ -34,12 +34,12 @@ class HashtagUsecaseTests {
                 mockHashtagRepository,
                 mockContext
             ).getDefaultHashtags(this)
-        ).isEqualTo(listOf(DefaultHashTagComponent(99999, "testHashtaaag", true)))
+        ).isEqualTo(listOf(DefaultHashTagComponent(99999, "testHashtaaag", 30, true)))
     }
 
     @Test
     fun updateDefaultHashtag_レポジトリのupdate用メソッドが1度呼ばれること() = runBlocking {
-        val testDefaultHashTagComponent = DefaultHashTagComponent(3, "", true)
+        val testDefaultHashTagComponent = DefaultHashTagComponent(3, "", 30, true)
         val expectedRecord = DefaultHashtagRecord(3, true)
         doNothing().`when`(mockHashtagRepository).updateDefaultHashtagRecord(expectedRecord, this)
 

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/HashtagUsecaseTests.kt
@@ -2,8 +2,6 @@ package com.ntetz.android.nyannyanengine_android.model.usecase
 
 import android.content.Context
 import com.google.common.truth.Truth
-import com.ntetz.android.nyannyanengine_android.R
-import com.ntetz.android.nyannyanengine_android.model.config.IDefaultHashtagConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.DefaultHashtagRecord
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import com.ntetz.android.nyannyanengine_android.model.repository.IHashtagsRepository
@@ -23,44 +21,20 @@ class HashtagUsecaseTests {
     private lateinit var mockHashtagRepository: IHashtagsRepository
 
     @Mock
-    private lateinit var mockDefaultHashtagConfig: IDefaultHashtagConfig
-
-    @Mock
     private lateinit var mockContext: Context
 
     @Test
-    fun getDefaultHashtagRecords_レポジトリにstringリソース有りidが登録されている時stringリソースが反映された値であること() = runBlocking {
-        `when`(mockHashtagRepository.getDefaultHashtagRecords(this)).thenReturn(
-            listOf(DefaultHashtagRecord(99999, true))
+    fun getDefaultHashtags_レポジトリ由来の値が得られること() = runBlocking {
+        `when`(mockHashtagRepository.getDefaultHashtags(this, mockContext)).thenReturn(
+            listOf(DefaultHashTagComponent(99999, "testHashtaaag", true))
         )
-        `when`(mockDefaultHashtagConfig.getTextBodyId(99999)).thenReturn(R.string.settings_title_hashtag_engine)
-        `when`(mockContext.getString(R.string.settings_title_hashtag_engine)).thenReturn("#testHashtaaaag")
 
         Truth.assertThat(
             HashtagUsecase(
                 mockHashtagRepository,
-                mockDefaultHashtagConfig,
                 mockContext
             ).getDefaultHashtags(this)
-        )
-            .isEqualTo(listOf(DefaultHashTagComponent(99999, "#testHashtaaaag", true)))
-    }
-
-    @Test
-    fun getDefaultHashtagRecords_レポジトリにstringリソース無しidが登録されている時空であること() = runBlocking {
-        `when`(mockHashtagRepository.getDefaultHashtagRecords(this)).thenReturn(
-            listOf(DefaultHashtagRecord(99999, true))
-        )
-        `when`(mockDefaultHashtagConfig.getTextBodyId(99999)).thenReturn(null)
-
-        Truth.assertThat(
-            HashtagUsecase(
-                mockHashtagRepository,
-                mockDefaultHashtagConfig,
-                mockContext
-            ).getDefaultHashtags(this)
-        )
-            .isEqualTo(listOf<DefaultHashTagComponent>())
+        ).isEqualTo(listOf(DefaultHashTagComponent(99999, "testHashtaaag", true)))
     }
 
     @Test
@@ -69,7 +43,7 @@ class HashtagUsecaseTests {
         val expectedRecord = DefaultHashtagRecord(3, true)
         doNothing().`when`(mockHashtagRepository).updateDefaultHashtagRecord(expectedRecord, this)
 
-        HashtagUsecase(mockHashtagRepository, mockDefaultHashtagConfig, mockContext).updateDefaultHashtag(
+        HashtagUsecase(mockHashtagRepository, mockContext).updateDefaultHashtag(
             testDefaultHashTagComponent,
             this
         )

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
@@ -1,6 +1,8 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
+import androidx.lifecycle.MutableLiveData
 import com.google.common.truth.Truth
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.User
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
@@ -195,6 +197,9 @@ class TweetsUsecaseTests {
                     user = User("dummyUsCsNomName", "dummyUsCsNomScNm", "https://ntetz.com/dummyUsCsNom.jpg")
                 )
             )
+            `when`(
+                mockAccountRepository.nyanNyanConfigEvent
+            ).thenReturn(MutableLiveData<NyanNyanConfig?>())
 
             val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository)
             Truth.assertThat(testUsecase.postTweet(tweetBody = "testtweeeetBody", scope = this))

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.usecase
 
+import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.NyanNyanConfig
@@ -7,6 +8,7 @@ import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.User
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
 import com.ntetz.android.nyannyanengine_android.model.repository.IAccountRepository
+import com.ntetz.android.nyannyanengine_android.model.repository.IHashtagsRepository
 import com.ntetz.android.nyannyanengine_android.model.repository.ITweetsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -25,11 +27,17 @@ class TweetsUsecaseTests {
     @Mock
     private lateinit var mockTweetsRepository: ITweetsRepository
 
+    @Mock
+    private lateinit var mockHashtagRepository: IHashtagsRepository
+
+    @Mock
+    private lateinit var mockContext: Context
+
     @Test
     fun getTweets_認証情報がない時未ログインの値を返すこと() = runBlocking {
         `when`(mockAccountRepository.loadTwitterUser(this)).thenReturn(null)
 
-        val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository)
+        val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
         Truth.assertThat(testUsecase.getLatestTweets(this)).isEqualTo(
             listOf(
                 Tweet(
@@ -71,7 +79,7 @@ class TweetsUsecaseTests {
                 )
             )
 
-            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository)
+            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
             Truth.assertThat(testUsecase.getLatestTweets(this)).isEqualTo(
                 listOf(
                     Tweet(
@@ -110,7 +118,7 @@ class TweetsUsecaseTests {
                 )
             )
 
-            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository)
+            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
             Truth.assertThat(testUsecase.getLatestTweets(this)).isEqualTo(
                 listOf(
                     Tweet(
@@ -155,7 +163,7 @@ class TweetsUsecaseTests {
                 )
             )
 
-            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository)
+            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
             Truth.assertThat(testUsecase.getPreviousTweets(maxId = 1234567890123456789, this)).isEqualTo(
                 listOf(
                     Tweet(
@@ -200,9 +208,12 @@ class TweetsUsecaseTests {
             `when`(
                 mockAccountRepository.nyanNyanConfigEvent
             ).thenReturn(MutableLiveData<NyanNyanConfig?>())
+            `when`(
+                mockHashtagRepository.getDefaultHashtags(this, mockContext)
+            ).thenReturn(listOf())
 
-            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository)
-            Truth.assertThat(testUsecase.postTweet(tweetBody = "testtweeeetBody", scope = this))
+            val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
+            Truth.assertThat(testUsecase.postTweet(tweetBody = "testtweeeetBody", scope = this, mockContext))
                 .isEqualTo(
                     Tweet(
                         id = 2828,

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
@@ -266,7 +266,7 @@ class TweetsUsecaseTests {
                 this,
                 mockContext
             )
-            delay(10) // これがないとCIでコケる
+            delay(20) // これがないとCIでコケる
 
             verify(mockTweetsRepository, times(1)).postTweet("testTweetBody\ntestTagBody", 10, testUser, this)
             return@withContext

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
@@ -198,6 +198,7 @@ class TweetsUsecaseTests {
             `when`(
                 mockTweetsRepository.postTweet(
                     tweetBody = "testtweeeetBody",
+                    point = 10,
                     token = testUser,
                     scope = this
                 )

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/UserActionUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/UserActionUsecaseTests.kt
@@ -1,0 +1,100 @@
+package com.ntetz.android.nyannyanengine_android.model.usecase
+
+import com.ntetz.android.nyannyanengine_android.model.entity.dao.firebase.AnalyticsEvent
+import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
+import com.ntetz.android.nyannyanengine_android.model.repository.IMetricsRepository
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class UserActionUsecaseTests {
+    @Mock
+    private lateinit var mockMetricsRepository: IMetricsRepository
+
+    @Test
+    fun tap_metricsRepositoryのlogEventが呼ばれること() = runBlocking {
+        val testStrMap = mapOf("testStr" to "testStrval")
+        val testNumMap = mapOf("testInt" to 4)
+        `when`(mockMetricsRepository.logEvent(AnalyticsEvent.TAP_TWEET, testStrMap, testNumMap, this)).thenReturn(null)
+
+        UserActionUsecase(mockMetricsRepository).tap(UserAction.TWEET, testStrMap, testNumMap, this)
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+        verify(mockMetricsRepository, times(1)).logEvent(
+            AnalyticsEvent.TAP_TWEET,
+            testStrMap,
+            testNumMap,
+            this
+        )
+    }
+
+    @Test
+    fun tap_渡す行動種別に応じた値でlogEventが呼ばれること() = runBlocking {
+        val testStrMap = mapOf("testStr" to "testStrval")
+        val testNumMap = mapOf("testInt" to 4)
+        `when`(mockMetricsRepository.logEvent(AnalyticsEvent.TAP_POST_NEKOGO, testStrMap, testNumMap, this)).thenReturn(
+            null
+        )
+
+        UserActionUsecase(mockMetricsRepository).tap(UserAction.POST_NEKOGO, testStrMap, testNumMap, this)
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+        verify(mockMetricsRepository, times(1)).logEvent(
+            AnalyticsEvent.TAP_POST_NEKOGO,
+            testStrMap,
+            testNumMap,
+            this
+        )
+    }
+
+    @Test
+    fun complete_metricsRepositoryのlogEventが呼ばれること() = runBlocking {
+        val testStrMap = mapOf("testStr" to "testStrval")
+        val testNumMap = mapOf("testInt" to 4)
+        `when`(
+            mockMetricsRepository.logEvent(
+                AnalyticsEvent.COMPLETE_SIGN_OUT,
+                testStrMap,
+                testNumMap,
+                this
+            )
+        ).thenReturn(null)
+
+        UserActionUsecase(mockMetricsRepository).complete(UserAction.SIGN_OUT, testStrMap, testNumMap, this)
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+        verify(mockMetricsRepository, times(1)).logEvent(
+            AnalyticsEvent.COMPLETE_SIGN_OUT,
+            testStrMap,
+            testNumMap,
+            this
+        )
+    }
+
+    @Test
+    fun complete_渡す行動種別に応じた値でlogEventが呼ばれること() = runBlocking {
+        val testStrMap = mapOf("testStr" to "testStrval")
+        val testNumMap = mapOf("testInt" to 4)
+        `when`(
+            mockMetricsRepository.logEvent(
+                AnalyticsEvent.COMPLETE_POST_NEKOGO,
+                testStrMap,
+                testNumMap,
+                this
+            )
+        ).thenReturn(null)
+
+        UserActionUsecase(mockMetricsRepository).complete(UserAction.POST_NEKOGO, testStrMap, testNumMap, this)
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+        verify(mockMetricsRepository, times(1)).logEvent(
+            AnalyticsEvent.COMPLETE_POST_NEKOGO,
+            testStrMap,
+            testNumMap,
+            this
+        )
+    }
+}

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
@@ -6,6 +6,7 @@ import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.room.TwitterUserRecord
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -31,6 +32,9 @@ class MainViewModelTests {
     @Mock
     private lateinit var mockTweetUsecase: ITweetsUsecase
 
+    @Mock
+    private lateinit var mockUserActionUsecase: IUserActionUsecase
+
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
@@ -52,8 +56,8 @@ class MainViewModelTests {
     @Test
     fun loadUserInfo_loadAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(null)
-        delay(10) // これがないとCIでコケる
-        MainViewModel(mockAccountUsecase, mockTweetUsecase).loadUserInfo()
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
+        delay(50) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).loadAccessToken(TestUtil.any())
         return@runBlocking
@@ -67,7 +71,7 @@ class MainViewModelTests {
             )
         )
 
-        val testViewModel = MainViewModel(mockAccountUsecase, mockTweetUsecase)
+        val testViewModel = MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase)
         testViewModel.loadUserInfo()
         delay(10) // これがないとCIでコケる
 
@@ -77,5 +81,37 @@ class MainViewModelTests {
             )
         )
         return@runBlocking
+    }
+
+    @Test
+    fun logOpenPostNekogoScreen_UserActionUsecaseのtapが呼ばれること() = runBlocking {
+        `when`(
+            mockUserActionUsecase.tap(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
+        ).thenReturn(null)
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).logOpenPostNekogoScreen()
+        delay(10) // これがないとCIでコケる
+
+        verify(mockUserActionUsecase, times(1)).tap(
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any()
+        )
+    }
+
+    @Test
+    fun logToggleTweet_UserActionUsecaseのtapが呼ばれること() = runBlocking {
+        `when`(
+            mockUserActionUsecase.tap(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
+        ).thenReturn(null)
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).logToggleTweet(3, true)
+
+        delay(10) // これがないとCIでコケる
+        verify(mockUserActionUsecase, times(1)).tap(
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any()
+        )
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
@@ -57,7 +57,7 @@ class MainViewModelTests {
     fun loadUserInfo_loadAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(null)
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
-        delay(50) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).loadAccessToken(TestUtil.any())
         return@runBlocking
@@ -67,7 +67,7 @@ class MainViewModelTests {
     fun loadUserInfo_fetchNyanNyanConfigが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.fetchNyanNyanConfig()).thenReturn(null)
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
-        delay(50) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchNyanNyanConfig()
         return@runBlocking
@@ -83,7 +83,7 @@ class MainViewModelTests {
 
         val testViewModel = MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase)
         testViewModel.loadUserInfo()
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.userInfoEvent.value).isEqualTo(
             TwitterUserRecord(
@@ -106,7 +106,7 @@ class MainViewModelTests {
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(mockUser)
         `when`(mockAccountUsecase.fetchNyanNyanUser(mockUser)).thenReturn(null)
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadNyanNyanUserInfo()
-        delay(50) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchNyanNyanUser(mockUser)
         return@runBlocking
@@ -118,7 +118,7 @@ class MainViewModelTests {
             mockUserActionUsecase.tap(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
         ).thenReturn(null)
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).logOpenPostNekogoScreen()
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockUserActionUsecase, times(1)).tap(
             TestUtil.any(),
@@ -135,7 +135,7 @@ class MainViewModelTests {
         ).thenReturn(null)
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).logToggleTweet(3, true)
 
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
         verify(mockUserActionUsecase, times(1)).tap(
             TestUtil.any(),
             TestUtil.any(),

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
@@ -66,8 +66,8 @@ class MainViewModelTests {
     @Test
     fun loadUserInfo_fetchNyanNyanConfigが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.fetchNyanNyanConfig()).thenReturn(null)
-        delay(10) // これがないとCIでコケる
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
+        delay(50) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchNyanNyanConfig()
         return@runBlocking
@@ -105,8 +105,8 @@ class MainViewModelTests {
         )
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(mockUser)
         `when`(mockAccountUsecase.fetchNyanNyanUser(mockUser)).thenReturn(null)
-        delay(10) // これがないとCIでコケる
         MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadNyanNyanUserInfo()
+        delay(50) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchNyanNyanUser(mockUser)
         return@runBlocking

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
@@ -64,6 +64,16 @@ class MainViewModelTests {
     }
 
     @Test
+    fun loadUserInfo_fetchNyanNyanConfigが呼ばれること() = runBlocking {
+        `when`(mockAccountUsecase.fetchNyanNyanConfig()).thenReturn(null)
+        delay(10) // これがないとCIでコケる
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
+
+        verify(mockAccountUsecase, times(1)).fetchNyanNyanConfig()
+        return@runBlocking
+    }
+
+    @Test
     fun loadUserInfo_対応するアクセストークン取得結果liveDataが更新されること() = runBlocking {
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(
             TwitterUserRecord(
@@ -80,6 +90,25 @@ class MainViewModelTests {
                 "testId", "testToken", "testTokenSecret", "testScName", "testName", null
             )
         )
+        return@runBlocking
+    }
+
+    @Test
+    fun loadNyanNyanUserInfo_fetchNyanNyanUserが呼ばれること() = runBlocking {
+        val mockUser = TwitterUserRecord(
+            "mockTu",
+            "testToken",
+            "testSecret",
+            "testScNm",
+            "testName",
+            null
+        )
+        `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(mockUser)
+        `when`(mockAccountUsecase.fetchNyanNyanUser(mockUser)).thenReturn(null)
+        delay(10) // これがないとCIでコケる
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadNyanNyanUserInfo()
+
+        verify(mockAccountUsecase, times(1)).fetchNyanNyanUser(mockUser)
         return@runBlocking
     }
 

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModelTests.kt
@@ -62,7 +62,7 @@ class PostNekogoViewModelTests {
     fun loadUserInfo_loadAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(null)
         PostNekogoViewModel(mockAccountUsecase, mockTweetsUsecase, mockUserActionUsecase).loadUserInfo()
-        delay(50) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Mockito.verify(mockAccountUsecase, Mockito.times(1)).loadAccessToken(TestUtil.any())
         return@runBlocking
@@ -78,7 +78,7 @@ class PostNekogoViewModelTests {
 
         val testViewModel = PostNekogoViewModel(mockAccountUsecase, mockTweetsUsecase, mockUserActionUsecase)
         testViewModel.loadUserInfo()
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.userInfoEvent.value).isEqualTo(
             TwitterUserRecord(
@@ -95,7 +95,7 @@ class PostNekogoViewModelTests {
             "testNekogo",
             mockContext
         )
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Mockito.verify(mockTweetsUsecase, Mockito.times(1)).postTweet(TestUtil.any(), TestUtil.any(), TestUtil.any())
         return@runBlocking
@@ -114,7 +114,7 @@ class PostNekogoViewModelTests {
 
         val testViewModel = PostNekogoViewModel(mockAccountUsecase, mockTweetsUsecase, mockUserActionUsecase)
         testViewModel.postNekogo("dummyTTweeett", mockContext)
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.postTweetEvent.value).isEqualTo(
             Tweet(
@@ -145,7 +145,7 @@ class PostNekogoViewModelTests {
             mockTweetsUsecase,
             mockUserActionUsecase
         ).postNekogo("dummyInputText", mockContext)
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Mockito.verify(mockUserActionUsecase, Mockito.times(1)).complete(
             TestUtil.any(),

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModelTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.post_nekogo
 
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
@@ -35,6 +36,9 @@ class PostNekogoViewModelTests {
 
     @Mock
     private lateinit var mockUserActionUsecase: IUserActionUsecase
+
+    @Mock
+    private lateinit var mockContext: Context
 
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
@@ -86,17 +90,20 @@ class PostNekogoViewModelTests {
 
     @Test
     fun postNekogo_postTweetが呼ばれること() = runBlocking {
-        `when`(mockTweetsUsecase.postTweet(TestUtil.any(), TestUtil.any())).thenReturn(null)
-        PostNekogoViewModel(mockAccountUsecase, mockTweetsUsecase, mockUserActionUsecase).postNekogo("testNekogo")
+        `when`(mockTweetsUsecase.postTweet(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(null)
+        PostNekogoViewModel(mockAccountUsecase, mockTweetsUsecase, mockUserActionUsecase).postNekogo(
+            "testNekogo",
+            mockContext
+        )
         delay(10) // これがないとCIでコケる
 
-        Mockito.verify(mockTweetsUsecase, Mockito.times(1)).postTweet(TestUtil.any(), TestUtil.any())
+        Mockito.verify(mockTweetsUsecase, Mockito.times(1)).postTweet(TestUtil.any(), TestUtil.any(), TestUtil.any())
         return@runBlocking
     }
 
     @Test
     fun postNekogo_対応するツイート取得結果liveDataが更新されること() = runBlocking {
-        `when`(mockTweetsUsecase.postTweet(TestUtil.any(), TestUtil.any())).thenReturn(
+        `when`(mockTweetsUsecase.postTweet(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(
             Tweet(
                 id = 2828,
                 text = "dummyUsCsNomPrev",
@@ -106,7 +113,7 @@ class PostNekogoViewModelTests {
         )
 
         val testViewModel = PostNekogoViewModel(mockAccountUsecase, mockTweetsUsecase, mockUserActionUsecase)
-        testViewModel.postNekogo("dummyTTweeett")
+        testViewModel.postNekogo("dummyTTweeett", mockContext)
         delay(10) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.postTweetEvent.value).isEqualTo(
@@ -122,7 +129,7 @@ class PostNekogoViewModelTests {
 
     @Test
     fun postNekogo_UserActionUsecaseのcompleteが呼ばれること() = runBlocking {
-        `when`(mockTweetsUsecase.postTweet(TestUtil.any(), TestUtil.any())).thenReturn(
+        `when`(mockTweetsUsecase.postTweet(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(
             Tweet(
                 id = 2828,
                 text = "dummyUsCsNomPrev",
@@ -137,7 +144,7 @@ class PostNekogoViewModelTests {
             mockAccountUsecase,
             mockTweetsUsecase,
             mockUserActionUsecase
-        ).postNekogo("dummyInputText")
+        ).postNekogo("dummyInputText", mockContext)
         delay(10) // これがないとCIでコケる
 
         Mockito.verify(mockUserActionUsecase, Mockito.times(1)).complete(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.DefaultHashTagComponent
 import com.ntetz.android.nyannyanengine_android.model.usecase.IHashtagUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -18,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
@@ -26,6 +28,9 @@ import org.mockito.junit.MockitoJUnitRunner
 class HashtagSettingViewModelTest {
     @Mock
     private lateinit var mockHashtagUsecase: IHashtagUsecase
+
+    @Mock
+    private lateinit var mockUserActionUsecase: IUserActionUsecase
 
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
@@ -48,7 +53,7 @@ class HashtagSettingViewModelTest {
     @Test
     fun initialize_getDefaultHashtagsが呼ばれること() = runBlocking {
         `when`(mockHashtagUsecase.getDefaultHashtags(TestUtil.any())).thenReturn(listOf())
-        HashtagSettingViewModel(mockHashtagUsecase).initialize()
+        HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase).initialize()
         delay(10) // これがないとCIでコケる
 
         verify(mockHashtagUsecase, times(1)).getDefaultHashtags(TestUtil.any())
@@ -67,7 +72,7 @@ class HashtagSettingViewModelTest {
             )
         )
 
-        val testViewModel = HashtagSettingViewModel(mockHashtagUsecase)
+        val testViewModel = HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase)
         testViewModel.initialize()
         delay(10) // イベント反映までの待ち時間
 
@@ -80,5 +85,33 @@ class HashtagSettingViewModelTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun updateDefaultHashtagComponent_updateDefaultHashtagが呼ばれること() = runBlocking {
+        val mockTag = DefaultHashTagComponent(5, "testtaaag", true)
+        doNothing().`when`(mockHashtagUsecase).updateDefaultHashtag(TestUtil.any(), TestUtil.any())
+
+        HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase).updateDefaultHashtagComponent(mockTag)
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+        verify(mockHashtagUsecase, times(1)).updateDefaultHashtag(TestUtil.any(), TestUtil.any())
+    }
+
+    @Test
+    fun updateDefaultHashtagComponent_userActionUsecaseのcompleteが呼ばれること() = runBlocking {
+        val mockTag = DefaultHashTagComponent(5, "testtaaag", true)
+        doNothing().`when`(mockHashtagUsecase).updateDefaultHashtag(TestUtil.any(), TestUtil.any())
+        `when`(
+            mockUserActionUsecase.complete(
+                TestUtil.any(),
+                TestUtil.any(),
+                TestUtil.any(),
+                TestUtil.any()
+            )
+        ).thenReturn(null)
+
+        HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase).updateDefaultHashtagComponent(mockTag)
+        delay(20) // これがないと、内部のCoroutineの起動を見届けられない模様。CI上だと落ちるので長めの時間
+        verify(mockUserActionUsecase, times(1)).complete(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
@@ -54,7 +54,7 @@ class HashtagSettingViewModelTest {
     fun initialize_getDefaultHashtagsが呼ばれること() = runBlocking {
         `when`(mockHashtagUsecase.getDefaultHashtags(TestUtil.any())).thenReturn(listOf())
         HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase).initialize()
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockHashtagUsecase, times(1)).getDefaultHashtags(TestUtil.any())
         return@runBlocking
@@ -75,7 +75,7 @@ class HashtagSettingViewModelTest {
 
         val testViewModel = HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase)
         testViewModel.initialize()
-        delay(10) // イベント反映までの待ち時間
+        delay(20) // イベント反映までの待ち時間
 
         Truth.assertThat(testViewModel.defaultHashtagComponents.value).isEqualTo(
             listOf(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModelTest.kt
@@ -67,6 +67,7 @@ class HashtagSettingViewModelTest {
                 DefaultHashTagComponent(
                     9999,
                     "#testHashtaaaagVM",
+                    30,
                     true
                 )
             )
@@ -81,6 +82,7 @@ class HashtagSettingViewModelTest {
                 DefaultHashTagComponent(
                     9999,
                     "#testHashtaaaagVM",
+                    30,
                     true
                 )
             )
@@ -89,7 +91,7 @@ class HashtagSettingViewModelTest {
 
     @Test
     fun updateDefaultHashtagComponent_updateDefaultHashtagが呼ばれること() = runBlocking {
-        val mockTag = DefaultHashTagComponent(5, "testtaaag", true)
+        val mockTag = DefaultHashTagComponent(5, "testtaaag", 30, true)
         doNothing().`when`(mockHashtagUsecase).updateDefaultHashtag(TestUtil.any(), TestUtil.any())
 
         HashtagSettingViewModel(mockHashtagUsecase, mockUserActionUsecase).updateDefaultHashtagComponent(mockTag)
@@ -99,7 +101,7 @@ class HashtagSettingViewModelTest {
 
     @Test
     fun updateDefaultHashtagComponent_userActionUsecaseのcompleteが呼ばれること() = runBlocking {
-        val mockTag = DefaultHashTagComponent(5, "testtaaag", true)
+        val mockTag = DefaultHashTagComponent(5, "testtaaag", 30, true)
         doNothing().`when`(mockHashtagUsecase).updateDefaultHashtag(TestUtil.any(), TestUtil.any())
         `when`(
             mockUserActionUsecase.complete(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
@@ -53,7 +53,7 @@ class SignInViewModelTests {
     fun executeSignIn_fetchAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(null)
         SignInViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignIn("authVerifierDummy", "oauthTokenDummy")
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())
         return@runBlocking
@@ -70,7 +70,7 @@ class SignInViewModelTests {
 
         val testViewModel = SignInViewModel(mockAccountUsecase, mockUserActionUsecase)
         testViewModel.executeSignIn("authVerifierDummy", "oauthTokenDummy")
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.signInEvent.value).isEqualTo(
             SignInResultComponent(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.SignInResultComponent
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -27,6 +28,9 @@ class SignInViewModelTests {
     @Mock
     private lateinit var mockAccountUsecase: IAccountUsecase
 
+    @Mock
+    private lateinit var mockUserActionUsecase: IUserActionUsecase
+
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
@@ -48,7 +52,7 @@ class SignInViewModelTests {
     @Test
     fun executeSignIn_fetchAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(null)
-        SignInViewModel(mockAccountUsecase).executeSignIn("authVerifierDummy", "oauthTokenDummy")
+        SignInViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignIn("authVerifierDummy", "oauthTokenDummy")
         delay(10) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())
@@ -64,7 +68,7 @@ class SignInViewModelTests {
             )
         )
 
-        val testViewModel = SignInViewModel(mockAccountUsecase)
+        val testViewModel = SignInViewModel(mockAccountUsecase, mockUserActionUsecase)
         testViewModel.executeSignIn("authVerifierDummy", "oauthTokenDummy")
         delay(10) // これがないとCIでコケる
 

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModelTests.kt
@@ -53,7 +53,7 @@ class SignOutViewModelTests {
     fun executeSignOut_deleteAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any())).thenReturn(null)
         SignOutViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignOut()
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).deleteAccessToken(TestUtil.any())
         return@runBlocking
@@ -67,7 +67,7 @@ class SignOutViewModelTests {
 
         val testViewModel = SignOutViewModel(mockAccountUsecase, mockUserActionUsecase)
         testViewModel.executeSignOut()
-        delay(10) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         Truth.assertThat(testViewModel.signOutEvent.value).isEqualTo(
             AccessTokenInvalidation("viewModelTestInvalidation!")
@@ -84,7 +84,7 @@ class SignOutViewModelTests {
             mockUserActionUsecase.complete(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
         ).thenReturn(null)
         SignOutViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignOut()
-        delay(50) // これがないとCIでコケる
+        delay(20) // これがないとCIでコケる
 
         verify(mockUserActionUsecase, times(1)).complete(
             TestUtil.any(),

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModelTests.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.AccessTokenInvalidation
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
+import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -27,6 +28,9 @@ class SignOutViewModelTests {
     @Mock
     private lateinit var mockAccountUsecase: IAccountUsecase
 
+    @Mock
+    private lateinit var mockUserActionUsecase: IUserActionUsecase
+
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
@@ -48,7 +52,7 @@ class SignOutViewModelTests {
     @Test
     fun executeSignOut_deleteAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any())).thenReturn(null)
-        SignOutViewModel(mockAccountUsecase).executeSignOut()
+        SignOutViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignOut()
         delay(10) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).deleteAccessToken(TestUtil.any())
@@ -61,7 +65,7 @@ class SignOutViewModelTests {
             AccessTokenInvalidation("viewModelTestInvalidation!")
         )
 
-        val testViewModel = SignOutViewModel(mockAccountUsecase)
+        val testViewModel = SignOutViewModel(mockAccountUsecase, mockUserActionUsecase)
         testViewModel.executeSignOut()
         delay(10) // これがないとCIでコケる
 
@@ -69,5 +73,24 @@ class SignOutViewModelTests {
             AccessTokenInvalidation("viewModelTestInvalidation!")
         )
         return@runBlocking
+    }
+
+    @Test
+    fun executeSignOut_UserActionUsecaseのcompleteが呼ばれること() = runBlocking {
+        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any())).thenReturn(
+            AccessTokenInvalidation("viewModelTestInvalidation!")
+        )
+        `when`(
+            mockUserActionUsecase.complete(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
+        ).thenReturn(null)
+        SignOutViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignOut()
+        delay(50) // これがないとCIでコケる
+
+        verify(mockUserActionUsecase, times(1)).complete(
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any()
+        )
     }
 }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/util/NekosanExtensionTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/util/NekosanExtensionTests.kt
@@ -80,4 +80,14 @@ class NekosanExtensionTests {
     fun isNekogo_type1単体と未登録はっしゅたぐ1つがfalse() {
         Truth.assertThat("にゃ1 #にゃんにゃんのエンジン".isNekogo(mockContext)).isFalse()
     }
+
+    @Test
+    fun nekosanPoint_登録済み絵文字に対して高い点数を返す() {
+        Truth.assertThat("にゃ🌈".nekosanPoint()).isEqualTo(80)
+    }
+
+    @Test
+    fun nekosanPoint_未登録絵文字に対してデフォルトの点数を返す() {
+        Truth.assertThat("にゃ🖨".nekosanPoint()).isEqualTo(10)
+    }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,22 @@ stages:
         mv app/build.gradle.versioned app/build.gradle
       displayName: 'build.gradleのVersionCode更新'
     - task: DownloadSecureFile@1
+      displayName: 'Firebase dev環境用の設定ファイルを取得'
+      name: FirebaseDevSettings
+      inputs:
+        secureFile: nyannyanengine-android-google-services-dev.json
+    - script: |
+        sudo ln -s $(FirebaseDevSettings.secureFilePath) app/src/dev/google-services.json
+      displayName: 'Firebase dev環境用設定ファイルの参照をプロジェクト内部に設置'
+    - task: DownloadSecureFile@1
+      displayName: 'Firebase prd環境用の設定ファイルを取得'
+      name: FirebasePrdSettings
+      inputs:
+        secureFile: nyannyanengine-android-google-services-prd.json
+    - script: |
+        sudo ln -s $(FirebasePrdSettings.secureFilePath) app/src/prd/google-services.json
+      displayName: 'Firebase prd環境用設定ファイルの参照をプロジェクト内部に設置'
+    - task: DownloadSecureFile@1
       displayName: 'App Distribution dev環境用のクレデンシャルを取得'
       name: deployUserDevCredential
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,22 @@ stages:
   - job: check_job
     displayName: 標準のcheckエラー検出
     steps:
+    - task: DownloadSecureFile@1
+      displayName: 'Firebase dev環境用の設定ファイルを取得'
+      name: FirebaseDevSettings
+      inputs:
+        secureFile: nyannyanengine-android-google-services-dev.json
+    - script: |
+        sudo ln -s $(FirebaseDevSettings.secureFilePath) app/src/dev/google-services.json
+      displayName: 'Firebase dev環境用設定ファイルの参照をプロジェクト内部に設置'
+    - task: DownloadSecureFile@1
+      displayName: 'Firebase prd環境用の設定ファイルを取得'
+      name: FirebasePrdSettings
+      inputs:
+        secureFile: nyannyanengine-android-google-services-prd.json
+    - script: |
+        sudo ln -s $(FirebasePrdSettings.secureFilePath) app/src/prd/google-services.json
+      displayName: 'Firebase prd環境用設定ファイルの参照をプロジェクト内部に設置'
     - script: |
         echo $(Build.BuildId) | xargs -I {} sed -e 's/versionCode 1/versionCode {}/g' app/build.gradle > app/build.gradle.versioned
         diff app/build.gradle.versioned app/build.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dependencies {
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.1'
         classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.1'
+        classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 


### PR DESCRIPTION
## 概要

Firebase Analytics, Crashlytics, Auth, Firestore周りの処理を追加。
それに絡む、はっしゅたぐ及びネコさんポイント周りの処理も作成。

## 参考

google-service.json 周りは、こちらを参考にした。
http://anvariation.com

close #40 
close #41
close #42
close #43

related #44