### PR TITLE
ログイン/ログアウトの画面遷移周りとオフラインクラッシュの修正

### DIFF
--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
@@ -39,6 +41,10 @@ class MainActivity : AppCompatActivity(), CoroutineScope, NavigationView.OnNavig
 
     private var isSignedIn: Boolean = false
 
+    private val _refreshTweetListEvent = MutableLiveData(false)
+    val refreshTweetListEvent: LiveData<Boolean>
+        get() = _refreshTweetListEvent
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -66,6 +72,10 @@ class MainActivity : AppCompatActivity(), CoroutineScope, NavigationView.OnNavig
     fun updateNyanNyanUserInfo(userInfo: NyanNyanUserComponent?) {
         main_nav_view.getHeaderView(0).current_rank.text = userInfo?.getCurrentRank(this)
         main_nav_view.getHeaderView(0).current_extends.text = userInfo?.currentExtends?.toString()
+    }
+
+    fun updateTweetList() {
+        _refreshTweetListEvent.postValue(true)
     }
 
     override fun onSupportNavigateUp() = (

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainActivity.kt
@@ -110,7 +110,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope, NavigationView.OnNavig
 
     private fun openAuthorizePage(scope: CoroutineScope) {
         scope.launch {
-            val authorizePageUri = accountUsecase.createAuthorizationEndpoint(this) ?: return@launch
+            val authorizePageUri = accountUsecase.createAuthorizationEndpoint(this, this@MainActivity) ?: return@launch
             startActivity(Intent(Intent.ACTION_VIEW, authorizePageUri))
             userActionUsecase.tap(userAction = UserAction.SIGN_IN, scope = this)
         }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/MainModule.kt
@@ -74,9 +74,9 @@ private val viewModelModule = module {
         val usecase = HashtagUsecase(repository, androidContext())
         HashtagSettingViewModel(usecase, get())
     }
-    viewModel { MainViewModel(get(), get(), get()) }
-    viewModel { SignInViewModel(get(), get()) }
-    viewModel { SignOutViewModel(get(), get()) }
+    viewModel { MainViewModel(get(), get(), get(), androidContext()) }
+    viewModel { SignInViewModel(get(), get(), androidContext()) }
+    viewModel { SignOutViewModel(get(), get(), androidContext()) }
     viewModel { PostNekogoViewModel(get(), get(), get()) }
 }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultTweetConfig.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultTweetConfig.kt
@@ -17,6 +17,19 @@ object DefaultTweetConfig {
         )
     )
 
+    val noConnectionRequestList = listOf(
+        Tweet(
+            id = 28,
+            createdAt = "Sat Jan 01 00:00:00 +0000 2021",
+            text = "にゃーん！回線状況を確認して、もう一回ひっぱり更新して欲しいにゃん😊",
+            user = User(
+                name = "にゃんにゃ先生",
+                screenName = "NNyansu",
+                profileImageUrlHttps = "https://nyannyanengine.firebaseapp.com/assets/nyannya_sensei.png"
+            )
+        )
+    )
+
     val tooManyRequestList = listOf(
         Tweet(
             id = 28,

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/NetworkConnectionInterceptor.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/NetworkConnectionInterceptor.kt
@@ -1,0 +1,26 @@
+package com.ntetz.android.nyannyanengine_android.model.dao.retrofit
+
+import android.content.Context
+import android.net.ConnectivityManager
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+class NetworkConnectionInterceptor(private val context: Context) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (!isConnected) {
+            throw NoConnectivityException()
+        }
+        val builder: Request.Builder = chain.request().newBuilder()
+        return chain.proceed(builder.build())
+    }
+
+    private val isConnected: Boolean
+        get() {
+            val connectivityManager =
+                context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return false
+            val netInfo = connectivityManager.getActiveNetworkInfo()
+            return netInfo != null && netInfo.isConnected()
+        }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/NoConnectivityException.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/NoConnectivityException.kt
@@ -1,0 +1,8 @@
+package com.ntetz.android.nyannyanengine_android.model.dao.retrofit
+
+import java.io.IOException
+
+class NoConnectivityException : IOException() {
+    override val message: String
+        get() = "No Internet Connection"
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/TwitterApi.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/dao/retrofit/TwitterApi.kt
@@ -1,36 +1,43 @@
 package com.ntetz.android.nyannyanengine_android.model.dao.retrofit
 
+import android.content.Context
 import com.ntetz.android.nyannyanengine_android.model.config.TwitterEndpoints
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
 
 interface ITwitterApi {
-    val scalarClient: ITwitterApiEndpoints
-    val objectClient: ITwitterApiEndpoints
+    fun getScalarClient(context: Context): ITwitterApiEndpoints
+    fun getObjectClient(context: Context): ITwitterApiEndpoints
 }
 
 object TwitterApi : ITwitterApi {
-    override val scalarClient: ITwitterApiEndpoints = Retrofit
-        .Builder()
-        .baseUrl(TwitterEndpoints.baseEndpoint)
-        .addConverterFactory(ScalarsConverterFactory.create())
-        .build()
-        .create()
+    override fun getScalarClient(context: Context): ITwitterApiEndpoints {
+        val okHttpClient = OkHttpClient.Builder().addInterceptor(NetworkConnectionInterceptor(context)).build()
+        return Retrofit
+            .Builder()
+            .baseUrl(TwitterEndpoints.baseEndpoint)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .client(okHttpClient)
+            .build()
+            .create()
+    }
 
-    override val objectClient: ITwitterApiEndpoints
-        get() {
-            val moshi = Moshi.Builder()
-                .add(KotlinJsonAdapterFactory())
-                .build()
-            return Retrofit
-                .Builder()
-                .baseUrl(TwitterEndpoints.baseEndpoint)
-                .addConverterFactory(MoshiConverterFactory.create(moshi))
-                .build()
-                .create()
-        }
+    override fun getObjectClient(context: Context): ITwitterApiEndpoints {
+        val okHttpClient = OkHttpClient.Builder().addInterceptor(NetworkConnectionInterceptor(context)).build()
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        return Retrofit
+            .Builder()
+            .baseUrl(TwitterEndpoints.baseEndpoint)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(okHttpClient)
+            .build()
+            .create()
+    }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecase.kt
@@ -11,8 +11,8 @@ import com.ntetz.android.nyannyanengine_android.util.nekosanPoint
 import kotlinx.coroutines.CoroutineScope
 
 interface ITweetsUsecase {
-    suspend fun getLatestTweets(scope: CoroutineScope): List<Tweet>
-    suspend fun getPreviousTweets(maxId: Long, scope: CoroutineScope): List<Tweet>
+    suspend fun getLatestTweets(scope: CoroutineScope, context: Context): List<Tweet>
+    suspend fun getPreviousTweets(maxId: Long, scope: CoroutineScope, context: Context): List<Tweet>
     suspend fun postTweet(tweetBody: String, scope: CoroutineScope, context: Context): Tweet
 }
 
@@ -21,14 +21,14 @@ class TweetsUsecase(
     private val accountRepository: IAccountRepository,
     private val hashtagsRepository: IHashtagsRepository
 ) : ITweetsUsecase {
-    override suspend fun getLatestTweets(scope: CoroutineScope): List<Tweet> {
+    override suspend fun getLatestTweets(scope: CoroutineScope, context: Context): List<Tweet> {
         val user = accountRepository.loadTwitterUser(scope) ?: return DefaultTweetConfig.notSignInlist
-        return tweetsRepository.getLatestTweets(token = user, scope = scope)
+        return tweetsRepository.getLatestTweets(token = user, scope = scope, context = context)
     }
 
-    override suspend fun getPreviousTweets(maxId: Long, scope: CoroutineScope): List<Tweet> {
+    override suspend fun getPreviousTweets(maxId: Long, scope: CoroutineScope, context: Context): List<Tweet> {
         val user = accountRepository.loadTwitterUser(scope) ?: return DefaultTweetConfig.notSignInlist
-        return tweetsRepository.getPreviousTweets(maxId = maxId, token = user, scope = scope)
+        return tweetsRepository.getPreviousTweets(maxId = maxId, token = user, scope = scope, context = context)
     }
 
     override suspend fun postTweet(tweetBody: String, scope: CoroutineScope, context: Context): Tweet {
@@ -38,7 +38,13 @@ class TweetsUsecase(
 
         accountRepository.incrementNekosanPoint(totalPoint, user)
         accountRepository.incrementTweetCount(user)
-        return tweetsRepository.postTweet(getTweetBodyWithHashtags(tweetBody, hashtags), totalPoint, user, scope)
+        return tweetsRepository.postTweet(
+            getTweetBodyWithHashtags(tweetBody, hashtags),
+            totalPoint,
+            user,
+            scope,
+            context
+        )
     }
 
     private fun getTweetBodyWithHashtags(tweetBody: String, hashtags: List<DefaultHashTagComponent>): String {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -60,6 +60,10 @@ class MainFragment : Fragment() {
             // Firestoreからいい感じで同期的に取得できる処理があれば、configとuserの取得処理に2つのLiveDataを使わなくてすみそう。
             (activity as? MainActivity)?.updateNyanNyanUserInfo(it)
         })
+        (activity as? MainActivity)?.refreshTweetListEvent?.observe(viewLifecycleOwner, {
+            viewModel.loadUserInfo()
+            adapter.refresh()
+        })
         viewModel.loadUserInfo()
         setupAdapter()
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -23,7 +24,8 @@ import kotlinx.coroutines.launch
 class MainViewModel(
     private val accountUsecase: IAccountUsecase,
     private val tweetsUsecase: ITweetsUsecase,
-    private val userActionUsecase: IUserActionUsecase
+    private val userActionUsecase: IUserActionUsecase,
+    private val context: Context
 ) : ViewModel() {
     private val _userInfoEvent: MutableLiveData<TwitterUserRecord?> = MutableLiveData()
     val userInfoEvent: LiveData<TwitterUserRecord?>
@@ -38,7 +40,13 @@ class MainViewModel(
             pageSize = TwitterEndpoints.homeTimelineCountParamDefaultValue.toInt(),
             enablePlaceholders = false
         ),
-        pagingSourceFactory = { TweetsPagingSource(scope = viewModelScope, tweetsUsecase = tweetsUsecase) }
+        pagingSourceFactory = {
+            TweetsPagingSource(
+                scope = viewModelScope,
+                context = context,
+                tweetsUsecase = tweetsUsecase
+            )
+        }
     ).flow.cachedIn(viewModelScope)
 
     fun loadUserInfo() {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/TweetsPagingSource.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/TweetsPagingSource.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
+import android.content.Context
 import androidx.paging.PagingSource
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
@@ -7,13 +8,14 @@ import kotlinx.coroutines.CoroutineScope
 
 class TweetsPagingSource(
     private val tweetsUsecase: ITweetsUsecase,
-    private val scope: CoroutineScope
+    private val scope: CoroutineScope,
+    private val context: Context
 ) : PagingSource<Long, Tweet>() {
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, Tweet> {
         val maxId = params.key
 
         if (maxId == null) {
-            val tweets = tweetsUsecase.getLatestTweets(scope)
+            val tweets = tweetsUsecase.getLatestTweets(scope, context)
             val prevKey = null
             val nextKey = if (tweets[0].isError) null else tweets.last().id
             return LoadResult.Page(
@@ -24,7 +26,7 @@ class TweetsPagingSource(
         }
 
         return try {
-            val tweets = tweetsUsecase.getPreviousTweets(maxId, scope)
+            val tweets = tweetsUsecase.getPreviousTweets(maxId, scope, context)
             val prevKey = if (tweets[0].isError) maxId else tweets.first().id
             val nextKey = if (tweets[0].isError) null else tweets.last().id
             LoadResult.Page(

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.ntetz.android.nyannyanengine_android.MainActivity
 import com.ntetz.android.nyannyanengine_android.R
 import org.koin.android.viewmodel.ext.android.viewModel
 
@@ -33,8 +34,8 @@ class SignInFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         viewModel.signInEvent.observe(viewLifecycleOwner, Observer {
-            println("sign in finished! $it")
-            findNavController().navigate(R.id.action_singInFragment_to_mainFragment)
+            (activity as? MainActivity)?.updateTweetList()
+            findNavController().popBackStack()
         })
         viewModel.executeSignIn(
             oauthVerifier = this.args.oauthVerifier,

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_in
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -12,7 +13,8 @@ import kotlinx.coroutines.launch
 
 class SignInViewModel(
     private val accountUsecase: IAccountUsecase,
-    private val userActionUsecase: IUserActionUsecase
+    private val userActionUsecase: IUserActionUsecase,
+    private val context: Context
 ) : ViewModel() {
     private val _signInEvent: MutableLiveData<SignInResultComponent?> = MutableLiveData()
     val signInEvent: LiveData<SignInResultComponent?>
@@ -30,7 +32,8 @@ class SignInViewModel(
                 accountUsecase.fetchAccessToken(
                     oauthVerifier = oauthVerifier,
                     oauthToken = oauthToken,
-                    scope = this
+                    scope = this,
+                    context = context
                 )
             )
             userActionUsecase.complete(userAction = UserAction.SIGN_IN, scope = this)

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.ntetz.android.nyannyanengine_android.MainActivity
 import com.ntetz.android.nyannyanengine_android.R
 import org.koin.android.viewmodel.ext.android.viewModel
 
@@ -29,7 +30,8 @@ class SignOutFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         viewModel.signOutEvent.observe(viewLifecycleOwner, {
-            findNavController().navigate(R.id.action_signOutFragment_to_mainFragment)
+            (activity as? MainActivity)?.updateTweetList()
+            findNavController().popBackStack()
         })
         viewModel.executeSignOut()
     }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModel.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_out
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -12,7 +13,8 @@ import kotlinx.coroutines.launch
 
 class SignOutViewModel(
     private val accountUsecase: IAccountUsecase,
-    private val userActionUsecase: IUserActionUsecase
+    private val userActionUsecase: IUserActionUsecase,
+    private val context: Context
 ) : ViewModel() {
     private val _signOutEvent: MutableLiveData<AccessTokenInvalidation?> = MutableLiveData()
     val signOutEvent: LiveData<AccessTokenInvalidation?>
@@ -21,7 +23,7 @@ class SignOutViewModel(
     fun executeSignOut() {
         viewModelScope.launch {
             _signOutEvent.postValue(
-                accountUsecase.deleteAccessToken(this)
+                accountUsecase.deleteAccessToken(this, context)
             )
             userActionUsecase.complete(userAction = UserAction.SIGN_OUT, scope = this)
         }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepositoryTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/repository/TweetsRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.model.repository
 
+import android.content.Context
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
 import com.ntetz.android.nyannyanengine_android.model.config.ITwitterConfig
@@ -25,6 +26,9 @@ class TweetsRepositoryTests {
     @Mock
     private lateinit var mockTwitterConfig: ITwitterConfig
 
+    @Mock
+    private lateinit var mockContext: Context
+
     @Test
     fun getLatestTweets_Retrofitのレスポンス由来の値が得られること() = runBlocking {
         withContext(Dispatchers.IO) {
@@ -40,7 +44,7 @@ class TweetsRepositoryTests {
                         )
                     )
                 )
-            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+            `when`(mockTwitterApi.getObjectClient(mockContext)).thenReturn(mockEndpoints)
 
             `when`(mockTwitterConfig.apiSecret).thenReturn("")
             `when`(mockTwitterConfig.consumerKey).thenReturn("")
@@ -54,7 +58,9 @@ class TweetsRepositoryTests {
                 testRepository.getLatestTweets(
                     TwitterUserRecord(
                         "", "", "", "", "testName", null
-                    ), this
+                    ),
+                    this,
+                    mockContext
                 )
             )
                 .isEqualTo(
@@ -97,7 +103,7 @@ class TweetsRepositoryTests {
                         )
                     )
                 )
-            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+            `when`(mockTwitterApi.getObjectClient(mockContext)).thenReturn(mockEndpoints)
 
             `when`(mockTwitterConfig.apiSecret).thenReturn("")
             `when`(mockTwitterConfig.consumerKey).thenReturn("")
@@ -111,7 +117,9 @@ class TweetsRepositoryTests {
                 testRepository.getLatestTweets(
                     TwitterUserRecord(
                         "", "", "", "", "testName", null
-                    ), this
+                    ),
+                    this,
+                    mockContext
                 )
             )
                 .isEqualTo(
@@ -154,7 +162,7 @@ class TweetsRepositoryTests {
                         )
                     )
                 )
-            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+            `when`(mockTwitterApi.getObjectClient(mockContext)).thenReturn(mockEndpoints)
 
             `when`(mockTwitterConfig.apiSecret).thenReturn("")
             `when`(mockTwitterConfig.consumerKey).thenReturn("")
@@ -170,7 +178,8 @@ class TweetsRepositoryTests {
                     token = TwitterUserRecord(
                         "", "", "", "", "testName", null
                     ),
-                    this
+                    this,
+                    mockContext
                 )
             )
                 .isEqualTo(
@@ -199,7 +208,7 @@ class TweetsRepositoryTests {
                         user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
                     )
                 )
-            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+            `when`(mockTwitterApi.getObjectClient(mockContext)).thenReturn(mockEndpoints)
 
             `when`(mockTwitterConfig.apiSecret).thenReturn("")
             `when`(mockTwitterConfig.consumerKey).thenReturn("")
@@ -216,7 +225,8 @@ class TweetsRepositoryTests {
                     token = TwitterUserRecord(
                         "", "", "", "", "testName", null
                     ),
-                    scope = this
+                    scope = this,
+                    mockContext
                 )
             )
                 .isEqualTo(
@@ -243,7 +253,7 @@ class TweetsRepositoryTests {
                         user = User("dummyTextRepoName", "dummyTextRepoScNm", "https://ntetz.com/dummyTextRepo.jpg")
                     )
                 )
-            `when`(mockTwitterApi.objectClient).thenReturn(mockEndpoints)
+            `when`(mockTwitterApi.getObjectClient(mockContext)).thenReturn(mockEndpoints)
 
             `when`(mockTwitterConfig.apiSecret).thenReturn("")
             `when`(mockTwitterConfig.consumerKey).thenReturn("")
@@ -260,7 +270,8 @@ class TweetsRepositoryTests {
                     token = TwitterUserRecord(
                         "", "", "", "", "testName", null
                     ),
-                    scope = this
+                    scope = this,
+                    context = mockContext
                 ).point
             ).isEqualTo(300)
         }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
@@ -42,7 +42,7 @@ class TweetsUsecaseTests {
         `when`(mockAccountRepository.loadTwitterUser(this)).thenReturn(null)
 
         val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
-        Truth.assertThat(testUsecase.getLatestTweets(this)).isEqualTo(
+        Truth.assertThat(testUsecase.getLatestTweets(this, mockContext)).isEqualTo(
             listOf(
                 Tweet(
                     id = 28,
@@ -72,7 +72,13 @@ class TweetsUsecaseTests {
             `when`(mockAccountRepository.loadTwitterUser(this)).thenReturn(
                 testUser
             )
-            `when`(mockTweetsRepository.getLatestTweets(token = testUser, scope = this)).thenReturn(
+            `when`(
+                mockTweetsRepository.getLatestTweets(
+                    token = testUser,
+                    scope = this,
+                    context = mockContext
+                )
+            ).thenReturn(
                 listOf(
                     Tweet(
                         id = 2828,
@@ -84,7 +90,7 @@ class TweetsUsecaseTests {
             )
 
             val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
-            Truth.assertThat(testUsecase.getLatestTweets(this)).isEqualTo(
+            Truth.assertThat(testUsecase.getLatestTweets(this, mockContext)).isEqualTo(
                 listOf(
                     Tweet(
                         id = 2828,
@@ -111,7 +117,13 @@ class TweetsUsecaseTests {
             `when`(mockAccountRepository.loadTwitterUser(this)).thenReturn(
                 testUser
             )
-            `when`(mockTweetsRepository.getLatestTweets(token = testUser, scope = this)).thenReturn(
+            `when`(
+                mockTweetsRepository.getLatestTweets(
+                    token = testUser,
+                    scope = this,
+                    context = mockContext
+                )
+            ).thenReturn(
                 listOf(
                     Tweet(
                         id = 2828,
@@ -123,7 +135,7 @@ class TweetsUsecaseTests {
             )
 
             val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
-            Truth.assertThat(testUsecase.getLatestTweets(this)).isEqualTo(
+            Truth.assertThat(testUsecase.getLatestTweets(this, mockContext)).isEqualTo(
                 listOf(
                     Tweet(
                         id = 2828,
@@ -154,7 +166,8 @@ class TweetsUsecaseTests {
                 mockTweetsRepository.getPreviousTweets(
                     maxId = 1234567890123456789,
                     token = testUser,
-                    scope = this
+                    scope = this,
+                    context = mockContext
                 )
             ).thenReturn(
                 listOf(
@@ -168,7 +181,7 @@ class TweetsUsecaseTests {
             )
 
             val testUsecase = TweetsUsecase(mockTweetsRepository, mockAccountRepository, mockHashtagRepository)
-            Truth.assertThat(testUsecase.getPreviousTweets(maxId = 1234567890123456789, this)).isEqualTo(
+            Truth.assertThat(testUsecase.getPreviousTweets(maxId = 1234567890123456789, this, mockContext)).isEqualTo(
                 listOf(
                     Tweet(
                         id = 2828,
@@ -200,7 +213,8 @@ class TweetsUsecaseTests {
                     tweetBody = "testtweeeetBody",
                     point = 10,
                     token = testUser,
-                    scope = this
+                    scope = this,
+                    context = mockContext
                 )
             ).thenReturn(
                 Tweet(
@@ -268,7 +282,13 @@ class TweetsUsecaseTests {
             )
             delay(20) // これがないとCIでコケる
 
-            verify(mockTweetsRepository, times(1)).postTweet("testTweetBody\ntestTagBody", 10, testUser, this)
+            verify(mockTweetsRepository, times(1)).postTweet(
+                "testTweetBody\ntestTagBody",
+                10,
+                testUser,
+                this,
+                mockContext
+            )
             return@withContext
         }
     }

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModelTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
@@ -35,6 +36,9 @@ class MainViewModelTests {
     @Mock
     private lateinit var mockUserActionUsecase: IUserActionUsecase
 
+    @Mock
+    private lateinit var mockContext: Context
+
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
@@ -56,7 +60,7 @@ class MainViewModelTests {
     @Test
     fun loadUserInfo_loadAccessTokenが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(null)
-        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase, mockContext).loadUserInfo()
         delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).loadAccessToken(TestUtil.any())
@@ -66,7 +70,7 @@ class MainViewModelTests {
     @Test
     fun loadUserInfo_fetchNyanNyanConfigが呼ばれること() = runBlocking {
         `when`(mockAccountUsecase.fetchNyanNyanConfig()).thenReturn(null)
-        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadUserInfo()
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase, mockContext).loadUserInfo()
         delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchNyanNyanConfig()
@@ -81,7 +85,7 @@ class MainViewModelTests {
             )
         )
 
-        val testViewModel = MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase)
+        val testViewModel = MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase, mockContext)
         testViewModel.loadUserInfo()
         delay(20) // これがないとCIでコケる
 
@@ -105,7 +109,7 @@ class MainViewModelTests {
         )
         `when`(mockAccountUsecase.loadAccessToken(TestUtil.any())).thenReturn(mockUser)
         `when`(mockAccountUsecase.fetchNyanNyanUser(mockUser)).thenReturn(null)
-        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).loadNyanNyanUserInfo()
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase, mockContext).loadNyanNyanUserInfo()
         delay(20) // これがないとCIでコケる
 
         verify(mockAccountUsecase, times(1)).fetchNyanNyanUser(mockUser)
@@ -117,7 +121,12 @@ class MainViewModelTests {
         `when`(
             mockUserActionUsecase.tap(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
         ).thenReturn(null)
-        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).logOpenPostNekogoScreen()
+        MainViewModel(
+            mockAccountUsecase,
+            mockTweetUsecase,
+            mockUserActionUsecase,
+            mockContext
+        ).logOpenPostNekogoScreen()
         delay(20) // これがないとCIでコケる
 
         verify(mockUserActionUsecase, times(1)).tap(
@@ -133,7 +142,7 @@ class MainViewModelTests {
         `when`(
             mockUserActionUsecase.tap(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
         ).thenReturn(null)
-        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase).logToggleTweet(3, true)
+        MainViewModel(mockAccountUsecase, mockTweetUsecase, mockUserActionUsecase, mockContext).logToggleTweet(3, true)
 
         delay(20) // これがないとCIでコケる
         verify(mockUserActionUsecase, times(1)).tap(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/TweetsPagingSourceTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/main/TweetsPagingSourceTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
+import android.content.Context
 import androidx.paging.PagingSource
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
@@ -17,6 +18,9 @@ class TweetsPagingSourceTests {
     @Mock
     private lateinit var mockTweetUsecase: ITweetsUsecase
 
+    @Mock
+    private lateinit var mockContext: Context
+
     @Test
     fun load_初読み込みかつレスポンスありの時レスポンスを返す() = runBlocking {
         val mockTweets = listOf(
@@ -27,11 +31,11 @@ class TweetsPagingSourceTests {
                 user = User("dummyUsCsNomName", "dummyUsCsNomScNm", "https://ntetz.com/dummyUsCsNom.jpg")
             )
         )
-        `when`(mockTweetUsecase.getLatestTweets(this)).thenReturn(mockTweets)
+        `when`(mockTweetUsecase.getLatestTweets(this, mockContext)).thenReturn(mockTweets)
         val testLoadParam =
             PagingSource.LoadParams.Refresh<Long>(key = null, loadSize = 99, placeholdersEnabled = false)
 
-        val testSource = TweetsPagingSource(mockTweetUsecase, this)
+        val testSource = TweetsPagingSource(mockTweetUsecase, this, mockContext)
         Truth.assertThat(testSource.load(testLoadParam))
             .isEqualTo(
                 PagingSource.LoadResult.Page<Long, Tweet>(
@@ -53,11 +57,11 @@ class TweetsPagingSourceTests {
                 user = User("dummyUsCsNomName", "dummyUsCsNomScNm", "https://ntetz.com/dummyUsCsNom.jpg")
             )
         )
-        `when`(mockTweetUsecase.getLatestTweets(this)).thenReturn(mockTweets)
+        `when`(mockTweetUsecase.getLatestTweets(this, mockContext)).thenReturn(mockTweets)
         val testLoadParam =
             PagingSource.LoadParams.Refresh<Long>(key = null, loadSize = 99, placeholdersEnabled = false)
 
-        val testSource = TweetsPagingSource(mockTweetUsecase, this)
+        val testSource = TweetsPagingSource(mockTweetUsecase, this, mockContext)
         Truth.assertThat(testSource.load(testLoadParam))
             .isEqualTo(
                 PagingSource.LoadResult.Page<Long, Tweet>(
@@ -85,11 +89,11 @@ class TweetsPagingSourceTests {
                 user = User("dummyUsCsNomName", "dummyUsCsNomScNm", "https://ntetz.com/dummyUsCsNom.jpg")
             )
         )
-        `when`(mockTweetUsecase.getPreviousTweets(2828, this)).thenReturn(mockTweets)
+        `when`(mockTweetUsecase.getPreviousTweets(2828, this, mockContext)).thenReturn(mockTweets)
         val testLoadParam =
             PagingSource.LoadParams.Refresh<Long>(key = 2828, loadSize = 99, placeholdersEnabled = false)
 
-        val testSource = TweetsPagingSource(mockTweetUsecase, this)
+        val testSource = TweetsPagingSource(mockTweetUsecase, this, mockContext)
         Truth.assertThat(testSource.load(testLoadParam))
             .isEqualTo(
                 PagingSource.LoadResult.Page<Long, Tweet>(
@@ -111,11 +115,11 @@ class TweetsPagingSourceTests {
                 user = User("dummyUsCsNomName", "dummyUsCsNomScNm", "https://ntetz.com/dummyUsCsNom.jpg")
             )
         )
-        `when`(mockTweetUsecase.getPreviousTweets(2828, this)).thenReturn(mockTweets)
+        `when`(mockTweetUsecase.getPreviousTweets(2828, this, mockContext)).thenReturn(mockTweets)
         val testLoadParam =
             PagingSource.LoadParams.Refresh<Long>(key = 2828, loadSize = 99, placeholdersEnabled = false)
 
-        val testSource = TweetsPagingSource(mockTweetUsecase, this)
+        val testSource = TweetsPagingSource(mockTweetUsecase, this, mockContext)
         Truth.assertThat(testSource.load(testLoadParam))
             .isEqualTo(
                 PagingSource.LoadResult.Page<Long, Tweet>(

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModelTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_in
 
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
@@ -31,6 +32,9 @@ class SignInViewModelTests {
     @Mock
     private lateinit var mockUserActionUsecase: IUserActionUsecase
 
+    @Mock
+    private lateinit var mockContext: Context
+
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
@@ -51,24 +55,46 @@ class SignInViewModelTests {
 
     @Test
     fun executeSignIn_fetchAccessTokenが呼ばれること() = runBlocking {
-        `when`(mockAccountUsecase.fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(null)
-        SignInViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignIn("authVerifierDummy", "oauthTokenDummy")
+        `when`(
+            mockAccountUsecase.fetchAccessToken(
+                TestUtil.any(),
+                TestUtil.any(),
+                TestUtil.any(),
+                TestUtil.any()
+            )
+        ).thenReturn(null)
+        SignInViewModel(mockAccountUsecase, mockUserActionUsecase, mockContext).executeSignIn(
+            "authVerifierDummy",
+            "oauthTokenDummy"
+        )
         delay(20) // これがないとCIでコケる
 
-        verify(mockAccountUsecase, times(1)).fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())
+        verify(mockAccountUsecase, times(1)).fetchAccessToken(
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any(),
+            TestUtil.any()
+        )
         return@runBlocking
     }
 
     @Test
     fun executeSignIn_対応するアクセストークン取得結果liveDataが更新されること() = runBlocking {
-        `when`(mockAccountUsecase.fetchAccessToken(TestUtil.any(), TestUtil.any(), TestUtil.any())).thenReturn(
+        `when`(
+            mockAccountUsecase.fetchAccessToken(
+                TestUtil.any(),
+                TestUtil.any(),
+                TestUtil.any(),
+                TestUtil.any()
+            )
+        ).thenReturn(
             SignInResultComponent(
                 isSucceeded = true,
                 errorMessage = "testTokenEventTest"
             )
         )
 
-        val testViewModel = SignInViewModel(mockAccountUsecase, mockUserActionUsecase)
+        val testViewModel = SignInViewModel(mockAccountUsecase, mockUserActionUsecase, mockContext)
         testViewModel.executeSignIn("authVerifierDummy", "oauthTokenDummy")
         delay(20) // これがないとCIでコケる
 

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModelTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModelTests.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_out
 
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth
 import com.ntetz.android.nyannyanengine_android.TestUtil
@@ -31,6 +32,9 @@ class SignOutViewModelTests {
     @Mock
     private lateinit var mockUserActionUsecase: IUserActionUsecase
 
+    @Mock
+    private lateinit var mockContext: Context
+
     // この記述がないとviewModelScopeのlaunchがランタイムエラーする
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
@@ -51,21 +55,21 @@ class SignOutViewModelTests {
 
     @Test
     fun executeSignOut_deleteAccessTokenが呼ばれること() = runBlocking {
-        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any())).thenReturn(null)
-        SignOutViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignOut()
+        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any(), TestUtil.any())).thenReturn(null)
+        SignOutViewModel(mockAccountUsecase, mockUserActionUsecase, mockContext).executeSignOut()
         delay(20) // これがないとCIでコケる
 
-        verify(mockAccountUsecase, times(1)).deleteAccessToken(TestUtil.any())
+        verify(mockAccountUsecase, times(1)).deleteAccessToken(TestUtil.any(), TestUtil.any())
         return@runBlocking
     }
 
     @Test
     fun executeSignOut_対応するアクセストークン取得結果liveDataが更新されること() = runBlocking {
-        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any())).thenReturn(
+        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any(), TestUtil.any())).thenReturn(
             AccessTokenInvalidation("viewModelTestInvalidation!")
         )
 
-        val testViewModel = SignOutViewModel(mockAccountUsecase, mockUserActionUsecase)
+        val testViewModel = SignOutViewModel(mockAccountUsecase, mockUserActionUsecase, mockContext)
         testViewModel.executeSignOut()
         delay(20) // これがないとCIでコケる
 
@@ -77,13 +81,13 @@ class SignOutViewModelTests {
 
     @Test
     fun executeSignOut_UserActionUsecaseのcompleteが呼ばれること() = runBlocking {
-        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any())).thenReturn(
+        `when`(mockAccountUsecase.deleteAccessToken(TestUtil.any(), TestUtil.any())).thenReturn(
             AccessTokenInvalidation("viewModelTestInvalidation!")
         )
         `when`(
             mockUserActionUsecase.complete(TestUtil.any(), TestUtil.any(), TestUtil.any(), TestUtil.any())
         ).thenReturn(null)
-        SignOutViewModel(mockAccountUsecase, mockUserActionUsecase).executeSignOut()
+        SignOutViewModel(mockAccountUsecase, mockUserActionUsecase, mockContext).executeSignOut()
         delay(20) // これがないとCIでコケる
 
         verify(mockUserActionUsecase, times(1)).complete(


### PR DESCRIPTION
## 概要

2つの不具合を修正

## 参考

minApiLevelを23とするならば、これをやるのが良さそう

https://stackoverflow.com/questions/57277759/getactivenetworkinfo-is-deprecated-in-api-29