### PR TITLE
ツイート一覧画面のデザイン更新

### DIFF
--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultTweetConfig.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/config/DefaultTweetConfig.kt
@@ -7,7 +7,7 @@ object DefaultTweetConfig {
     val notSignInlist = listOf(
         Tweet(
             id = 28,
-            createdAt = "2828/2/8",
+            createdAt = "Sat Jan 01 00:00:00 +0000 2021",
             text = "左上のボタンからログインするにゃあ♪\nあなたのTwitterをネコ語化だにゃ",
             user = User(
                 name = "にゃんにゃ先生",
@@ -33,7 +33,7 @@ object DefaultTweetConfig {
     val tooManyRequestList = listOf(
         Tweet(
             id = 28,
-            createdAt = "2828/2/8",
+            createdAt = "Sat Jan 01 00:00:00 +0000 2021",
             text = "いっぱい使ってくれてありがとにゃ🎊 \n猫さん休憩中だから、数十分後にもう一回試して欲しいにゃ",
             user = User(
                 name = "にゃんにゃ先生",
@@ -46,7 +46,7 @@ object DefaultTweetConfig {
     val undefinedErrorList = listOf(
         Tweet(
             id = 28,
-            createdAt = "2828/2/8",
+            createdAt = "Sat Jan 01 00:00:00 +0000 2021",
             text = "にゃーん。。。なんか調子が悪いにゃ。。。もうしばらくしてから遊んで欲しいにゃ。。。",
             user = User(
                 name = "にゃんにゃ先生",

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/retrofit/Tweet.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/retrofit/Tweet.kt
@@ -1,6 +1,10 @@
 package com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit
 
+import android.content.Context
+import com.ntetz.android.nyannyanengine_android.R
 import com.squareup.moshi.Json
+import java.text.SimpleDateFormat
+import java.util.*
 
 data class Tweet(
     val id: Long,
@@ -16,4 +20,30 @@ data class Tweet(
         get() = id.toInt() == 28
 
     var point: Int = 0
+
+    fun tweetedAt(context: Context): String? {
+        val tweetDate = createdAt.toDate() ?: return null
+        val now = Date()
+        val diff = now.time - tweetDate.time
+        if (diff < 1000 * 60) {
+            return listOf((diff / (1000)).toString(), context.getString(R.string.time_suffix_sec)).joinToString("")
+        }
+        if (diff < 1000 * 60 * 60) {
+            return listOf((diff / (1000 * 60)).toString(), context.getString(R.string.time_suffix_min)).joinToString("")
+        }
+        if (diff < 1000 * 60 * 60 * 24) {
+            return listOf(
+                (diff / (1000 * 60 * 60)).toString(),
+                context.getString(R.string.time_suffix_hour)
+            ).joinToString("")
+        }
+        return listOf(
+            (diff / (1000 * 60 * 60 * 24)).toString(),
+            context.getString(R.string.time_suffix_day)
+        ).joinToString("")
+    }
+
+    private fun String.toDate(): Date? {
+        return SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy", Locale.US).parse(this)
+    }
 }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/retrofit/User.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/model/entity/dao/retrofit/User.kt
@@ -10,4 +10,20 @@ data class User(
 
     @Json(name = "profile_image_url_https")
     var profileImageUrlHttps: String? = null
-)
+) {
+    val fineImageUrl: String?
+        get() {
+            val match =
+                Regex("""^https?://(.+)_normal(.+)$""").find(
+                    this.profileImageUrlHttps ?: return this.profileImageUrlHttps
+                )?.groups
+                    ?: return this.profileImageUrlHttps
+            if (match.size != 3) {
+                return this.profileImageUrlHttps
+            }
+
+            val urlBody = match[1]?.value ?: return this.profileImageUrlHttps
+            val fileExt = match[2]?.value ?: return this.profileImageUrlHttps
+            return listOf("https://", urlBody, fileExt).joinToString("")
+        }
+}

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -1,5 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
+import android.animation.LayoutTransition
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -24,6 +25,7 @@ class MainViewHolder(
             binding.isNyanNyan = !(binding.isNyanNyan as Boolean)
             viewModel.logToggleTweet(bindingAdapterPosition, (binding.isNyanNyan as Boolean))
         }
+        binding.tweetBodyFrame.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
         binding.isNyanNyan = !item.isError
         binding.nyanNyanTweetTextBody = item.text.toNyanNyan(context)
         binding.tweetTextBody = item.text

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -24,7 +24,7 @@ class MainViewHolder(
         }
         binding.isNyanNyan = !item.isError
         binding.nyanNyanTweetTextBody = item.text.toNyanNyan(context)
-        binding.tweetTextBody = item.createdAt + item.text
+        binding.tweetTextBody = item.tweetedAt(context) + item.text
         binding.lifecycleOwner = lifecycleOwner
     }
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -6,6 +6,8 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
+import coil.api.load
+import coil.transform.RoundedCornersTransformation
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.databinding.MainCellBinding
 import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Tweet
@@ -24,7 +26,16 @@ class MainViewHolder(
         }
         binding.isNyanNyan = !item.isError
         binding.nyanNyanTweetTextBody = item.text.toNyanNyan(context)
-        binding.tweetTextBody = item.tweetedAt(context) + item.text
+        binding.tweetTextBody = item.text
+
+        binding.twitterImage.load(item.user.fineImageUrl) {
+            transformations(RoundedCornersTransformation(16f))
+        }
+        val userName = "@${item.user.screenName}"
+        binding.screenName.text = userName
+        binding.name.text = item.user.name
+        binding.tweetedAt.text = item.tweetedAt(context)
+
         binding.lifecycleOwner = lifecycleOwner
     }
 

--- a/app/src/main/res/drawable/ic_baseline_message_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_message_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM18,14L6,14v-2h12v2zM18,11L6,11L6,9h12v2zM18,8L6,8L6,6h12v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_message_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_message_24.xml
@@ -3,7 +3,7 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
+    android:tint="@color/colorBackGround">
   <path
       android:fillColor="@android:color/white"
       android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM18,14L6,14v-2h12v2zM18,11L6,11L6,9h12v2zM18,8L6,8L6,6h12v2z"/>

--- a/app/src/main/res/layout/main_cell.xml
+++ b/app/src/main/res/layout/main_cell.xml
@@ -21,6 +21,10 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:background="?android:attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
         android:orientation="horizontal"
         android:padding="@dimen/middle_margin">
 
@@ -41,6 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/small_margin"
             android:layout_marginEnd="@dimen/small_margin"
+            android:background="@android:color/transparent"
             android:orientation="horizontal"
             android:weightSum="1"
             app:layout_constraintEnd_toEndOf="parent"
@@ -52,6 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.25"
+                android:background="@android:color/transparent"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:text="@string/default_twitter_name"
@@ -62,6 +68,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.35"
+                android:background="@android:color/transparent"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:text="@string/default_twitter_id"
@@ -72,6 +79,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.4"
+                android:background="@android:color/transparent"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:text="@string/default_tweeted_at"
@@ -85,6 +93,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:animateLayoutChanges="true"
+            android:background="@android:color/transparent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@+id/user_info"
             app:layout_constraintTop_toBottomOf="@+id/user_info">
@@ -96,6 +105,7 @@
                 android:layout_marginTop="@dimen/small_margin"
                 android:layout_marginEnd="@dimen/small_margin"
                 android:animateLayoutChanges="true"
+                android:background="@android:color/transparent"
                 android:text="@{isNyanNyan ? nyanNyanTweetTextBody : tweetTextBody}"
                 android:textAppearance="@style/TextAppearance.TweetListBody"
                 tool:text="tweet body" />

--- a/app/src/main/res/layout/main_cell.xml
+++ b/app/src/main/res/layout/main_cell.xml
@@ -80,18 +80,26 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/tweet_body"
+        <FrameLayout
+            android:id="@+id/tweet_body_frame"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/small_margin"
-            android:layout_marginEnd="@dimen/small_margin"
-            android:text="@{isNyanNyan ? nyanNyanTweetTextBody : tweetTextBody}"
-            android:textAppearance="@style/TextAppearance.TweetListBody"
+            android:animateLayoutChanges="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@+id/user_info"
-            app:layout_constraintTop_toBottomOf="@+id/user_info"
-            tool:text="tweet body" />
+            app:layout_constraintTop_toBottomOf="@+id/user_info">
+
+            <TextView
+                android:id="@+id/tweet_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/small_margin"
+                android:layout_marginEnd="@dimen/small_margin"
+                android:animateLayoutChanges="true"
+                android:text="@{isNyanNyan ? nyanNyanTweetTextBody : tweetTextBody}"
+                android:textAppearance="@style/TextAppearance.TweetListBody"
+                tool:text="tweet body" />
+        </FrameLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/main_cell.xml
+++ b/app/src/main/res/layout/main_cell.xml
@@ -4,6 +4,7 @@
     xmlns:tool="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="isNyanNyan"
             type="Boolean" />
@@ -23,15 +24,74 @@
         android:orientation="horizontal"
         android:padding="@dimen/middle_margin">
 
+        <ImageView
+            android:id="@+id/twitter_image"
+            android:layout_width="@dimen/image_middle"
+            android:layout_height="@dimen/image_middle"
+            android:layout_marginStart="@dimen/small_margin"
+            android:layout_marginTop="@dimen/small_margin"
+            android:contentDescription="@string/tweet_list_desc"
+            android:scaleType="fitCenter"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <LinearLayout
+            android:id="@+id/user_info"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/small_margin"
+            android:layout_marginEnd="@dimen/small_margin"
+            android:orientation="horizontal"
+            android:weightSum="1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/twitter_image"
+            app:layout_constraintTop_toTopOf="@+id/twitter_image">
+
+            <TextView
+                android:id="@+id/name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.25"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/default_twitter_name"
+                android:textAppearance="@style/TextAppearance.TweetListUserName" />
+
+            <TextView
+                android:id="@+id/screen_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.35"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/default_twitter_id"
+                android:textAppearance="@style/TextAppearance.TweetListUserMeta" />
+
+            <TextView
+                android:id="@+id/tweeted_at"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.4"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/default_tweeted_at"
+                android:textAlignment="viewEnd"
+                android:textAppearance="@style/TextAppearance.TweetListUserMeta" />
+
+        </LinearLayout>
+
         <TextView
             android:id="@+id/tweet_body"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/small_margin"
+            android:layout_marginEnd="@dimen/small_margin"
             android:text="@{isNyanNyan ? nyanNyanTweetTextBody : tweetTextBody}"
-            android:textAppearance="@style/TextAppearance.MenuListEntry"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tool:text="Hashtag name" />
+            android:textAppearance="@style/TextAppearance.TweetListBody"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/user_info"
+            app:layout_constraintTop_toBottomOf="@+id/user_info"
+            tool:text="tweet body" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -14,6 +14,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:theme="@style/ContentsViewTheme"
         tools:context="com.ntetz.android.nyannyanengine_android.ui.main.MainFragment">
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -38,6 +38,7 @@
             android:layout_marginEnd="@dimen/large_margin"
             android:layout_marginBottom="@dimen/large_margin"
             android:contentDescription="@string/home_timeline_description_post_nekogo"
+            android:src="@drawable/ic_baseline_message_24"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -8,7 +8,7 @@
     <fragment
         android:id="@+id/mainFragment"
         android:name="com.ntetz.android.nyannyanengine_android.ui.main.MainFragment"
-        android:label="main_fragment"
+        android:label="@string/default_timeline_name"
         tools:layout="@layout/main_fragment" >
         <action
             android:id="@+id/action_mainFragment_to_postNekogoFragment"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -38,4 +38,9 @@
     <string name="nekosan_nakigoe_type8">Myau</string>
     <string name="nekosan_nakigoe_type9">Nyan</string>
     <string name="nekosan_nakigoe_type99">Purr</string>
+
+    <string name="time_suffix_sec">s ago</string>
+    <string name="time_suffix_min">m ago</string>
+    <string name="time_suffix_hour">h ago</string>
+    <string name="time_suffix_day">d ago</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,7 +1,9 @@
 <resources>
     <string name="default_twitter_name">Dr. Nyannya</string>
     <string name="default_twitter_id">NNyansu</string>
+    <string name="default_tweeted_at">28 min ago</string>
     <string name="nav_header_desc">Account info</string>
+    <string name="tweet_list_desc">Tweet account info</string>
 
     <string name="home_timeline_description_post_nekogo">Post cat language</string>
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="default_timeline_name">Cat-san Viewer</string>
     <string name="default_twitter_name">Dr. Nyannya</string>
     <string name="default_twitter_id">NNyansu</string>
     <string name="default_tweeted_at">28 min ago</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -38,4 +38,9 @@
     <string name="nekosan_nakigoe_type8">にゃーおん</string>
     <string name="nekosan_nakigoe_type9">にゃあ</string>
     <string name="nekosan_nakigoe_type99">ごろごろ</string>
+
+    <string name="time_suffix_sec">秒前</string>
+    <string name="time_suffix_min">分前</string>
+    <string name="time_suffix_hour">時間前</string>
+    <string name="time_suffix_day">日前</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+    <string name="default_timeline_name">ネコさんビューアー</string>
     <string name="default_twitter_name">にゃんにゃ先生</string>
     <string name="default_twitter_id">NNyansu</string>
     <string name="default_tweeted_at">28分前</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,7 +1,9 @@
 <resources>
     <string name="default_twitter_name">にゃんにゃ先生</string>
     <string name="default_twitter_id">NNyansu</string>
+    <string name="default_tweeted_at">28分前</string>
     <string name="nav_header_desc">アカウント情報</string>
+    <string name="tweet_list_desc">ツイートアカウント情報</string>
 
     <string name="home_timeline_description_post_nekogo">ねこ語をツイート</string>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#fdf6e3</color>
+    <color name="colorPrimary">#ffffff</color>
     <color name="colorPrimaryDark">#cac3b1</color>
     <color name="colorSecondary">#268ad2</color>
     <color name="onPrimary">#002b36</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="colorPrimary">#ffffff</color>
     <color name="colorPrimaryDark">#cac3b1</color>
-    <color name="colorSecondary">#268ad2</color>
+    <color name="colorAccent">#268ad2</color>
+    <color name="colorBackGround">#fdf6e3</color>
     <color name="onPrimary">#002b36</color>
 </resources>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -5,6 +5,7 @@
     <dimen name="small_margin">8dp</dimen>
 
     <dimen name="image_large">64dp</dimen>
+    <dimen name="image_middle">48dp</dimen>
 
     <dimen name="large_text_size">24sp</dimen>
     <dimen name="middle_text_size">18sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,9 @@
 
     <string name="default_twitter_name">Dr. Nyannya</string>
     <string name="default_twitter_id">NNyansu</string>
+    <string name="default_tweeted_at">28 min ago</string>
     <string name="nav_header_desc">Account info</string>
+    <string name="tweet_list_desc">Tweet account info</string>
 
     <string name="home_timeline_description_post_nekogo">Post cat language</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,9 @@
     <string name="nekosan_nakigoe_type8">Myau</string>
     <string name="nekosan_nakigoe_type9">Nyan</string>
     <string name="nekosan_nakigoe_type99">Purr</string>
+
+    <string name="time_suffix_sec">s ago</string>
+    <string name="time_suffix_min">m ago</string>
+    <string name="time_suffix_hour">h ago</string>
+    <string name="time_suffix_day">d ago</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">NyanNyanEngine_Android</string>
 
+    <string name="default_timeline_name">Cat-san Viewer</string>
     <string name="default_twitter_name">Dr. Nyannya</string>
     <string name="default_twitter_id">NNyansu</string>
     <string name="default_tweeted_at">28 min ago</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,7 +4,6 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorSecondary</item>
         <item name="titleTextColor">@color/onPrimary</item>
         <item name="colorControlNormal">@color/onPrimary</item>
     </style>
@@ -16,6 +15,12 @@
 
     <style name="MainDrawerTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="itemTextAppearance">@style/TextAppearance.MenuListEntry</item>
+    </style>
+
+    <style name="ContentsViewTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:background">@color/colorBackGround</item>
+        <!-- 明示的に指定しない場合、backgroundの色に応じた色、ここでは緑色に自動的に設定される。 -->
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
 
     <style name="TextAppearance.SelfTwitterName" parent="TextAppearance.AppCompat.Body1">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,4 +33,20 @@
         <item name="android:textSize">@dimen/middle_text_size</item>
     </style>
 
+    <style name="TextAppearance.TweetListUserName" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">@dimen/middle_text_size</item>
+    </style>
+
+    <style name="TextAppearance.TweetListUserMeta" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textSize">@dimen/small_text_size</item>
+    </style>
+
+    <style name="TextAppearance.TweetListBody" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/onPrimary</item>
+        <item name="android:textSize">@dimen/middle_text_size</item>
+    </style>
+
 </resources>

--- a/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
+++ b/app/src/test/java/com/ntetz/android/nyannyanengine_android/model/usecase/TweetsUsecaseTests.kt
@@ -47,7 +47,7 @@ class TweetsUsecaseTests {
                 Tweet(
                     id = 28,
                     text = "左上のボタンからログインするにゃあ♪\nあなたのTwitterをネコ語化だにゃ",
-                    createdAt = "2828/2/8",
+                    createdAt = "Sat Jan 01 00:00:00 +0000 2021",
                     user = User(
                         name = "にゃんにゃ先生",
                         screenName = "NNyansu",


### PR DESCRIPTION
## 変更内容詳細

変更前 | 変更後
---|---
![device-2021-01-10-154905](https://user-images.githubusercontent.com/38374045/104116410-a0cf4680-535b-11eb-90b5-109e262bd61a.gif) | ![device-2021-01-10-154800](https://user-images.githubusercontent.com/38374045/104116405-990fa200-535b-11eb-999b-760a5a9f52b3.gif)

## 参考

アニメーション周りは下記が参考になった

### レイアウト更新

https://qiita.com/oya-t/items/87dfb14d44a808572042

### リップル

https://qiita.com/kaleidot725/items/b1f345974bf3e562f672
https://stackoverflow.com/questions/19541581/how-to-make-a-linearlayout-partially-transparent-in-android

close #87