### PR TITLE
ツイート一覧画面のデザインの更なる改良

### DIFF
--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainFragment.kt
@@ -4,9 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.fragment.findNavController
+import androidx.paging.LoadState
 import com.ntetz.android.nyannyanengine_android.MainActivity
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.databinding.MainFragmentBinding
@@ -48,6 +51,12 @@ class MainFragment : Fragment() {
         binding.postNekogoFragmentOpenButton.setOnClickListener {
             viewModel.logOpenPostNekogoScreen()
             findNavController().navigate(R.id.action_mainFragment_to_postNekogoFragment)
+        }
+
+        lifecycleScope.launch {
+            adapter.loadStateFlow.collectLatest {
+                binding.tweetProgressLoader.isGone = !(it.refresh is LoadState.Loading)
+            }
         }
 
         viewModel.userInfoEvent.observe(viewLifecycleOwner, {

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -31,6 +31,7 @@ class MainViewHolder(
         binding.tweetTextBody = item.text
 
         binding.twitterImage.load(item.user.fineImageUrl) {
+            placeholder(R.mipmap.ic_launcher_foreground)
             crossfade(true)
             transformations(RoundedCornersTransformation(16f))
         }

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -31,6 +31,7 @@ class MainViewHolder(
         binding.tweetTextBody = item.text
 
         binding.twitterImage.load(item.user.fineImageUrl) {
+            crossfade(true)
             transformations(RoundedCornersTransformation(16f))
         }
         val userName = "@${item.user.screenName}"

--- a/app/src/main/res/layout/main_cell.xml
+++ b/app/src/main/res/layout/main_cell.xml
@@ -32,7 +32,6 @@
             android:id="@+id/twitter_image"
             android:layout_width="@dimen/image_middle"
             android:layout_height="@dimen/image_middle"
-            android:layout_marginStart="@dimen/small_margin"
             android:layout_marginTop="@dimen/small_margin"
             android:contentDescription="@string/tweet_list_desc"
             android:scaleType="fitCenter"

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -31,6 +31,17 @@
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+        <ProgressBar
+            android:id="@+id/tweet_progress_loader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/postNekogoFragmentOpenButton"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## 変更内容詳細

余白調整と、画像の読み込み時により滑らかになるよう改良

変更前|変更後
---|---
<img width="439" alt="image" src="https://user-images.githubusercontent.com/38374045/104118267-0a0a8600-536b-11eb-928e-0d461dd021f0.png">|<img width="439" alt="image" src="https://user-images.githubusercontent.com/38374045/104118300-37efca80-536b-11eb-8499-34824c70eb33.png">

related #87