### PR TITLE
Pixel 4においてDrawer上部がシステムウィンドウに隠れてしまう問題を解消

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,6 @@
     android:id="@+id/main_drawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".MainActivity"
     tools:openDrawer="start">
 


### PR DESCRIPTION
## 概要

ストア用にスクショを作ろうとPixel 4のエミュレータで動かしてみたらレイアウトが崩れていたので修正

## 変更内容詳細

修正前|修正後
---|---
<img width="404" alt="image" src="https://user-images.githubusercontent.com/38374045/104830975-78999780-58c7-11eb-85c2-73ae54e75100.png">|<img width="404" alt="image" src="https://user-images.githubusercontent.com/38374045/104830966-67e92180-58c7-11eb-90a2-f41ee7d7ad3e.png">
