### PR TITLE
App/Status Barの色統一及びそれに伴う各所背景色更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The funny Twitter client android app. Every tweet you post and see are converted
 ## Designs
 
 <p align="center">
-	<img width="180 alt="image" src="https://user-images.githubusercontent.com/38374045/104811999-940e8f00-5842-11eb-889c-3c758e5e080c.png">
-	<img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104812008-a38dd800-5842-11eb-9f0a-7066c4977b70.png">
+	<img width="180 alt="image" src="https://user-images.githubusercontent.com/38374045/104833389-a5f04080-58db-11eb-9601-02bf1d1e65ee.png">
+	<img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833404-c3bda580-58db-11eb-93e4-b8a6e6ace57f.png">
 </p>
 
 ## Architecture

--- a/app/src/main/res/color/tweet_button_color.xml
+++ b/app/src/main/res/color/tweet_button_color.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/colorPrimaryDark" android:state_enabled="false" />
+    <item android:color="@color/colorPrimary" android:state_enabled="false" />
     <item android:color="@color/colorAccent" />
 </selector>

--- a/app/src/main/res/drawable/side_nav_bar.xml
+++ b/app/src/main/res/drawable/side_nav_bar.xml
@@ -3,6 +3,6 @@
     <gradient
         android:angle="135"
         android:endColor="@color/colorPrimary"
-        android:startColor="@color/colorPrimary"
+        android:startColor="@color/colorBackGround"
         android:type="linear" />
 </shape>

--- a/app/src/main/res/drawable/side_nav_bar.xml
+++ b/app/src/main/res/drawable/side_nav_bar.xml
@@ -2,7 +2,7 @@
     android:shape="rectangle">
     <gradient
         android:angle="135"
-        android:endColor="@color/colorPrimaryDark"
+        android:endColor="@color/colorPrimary"
         android:startColor="@color/colorPrimary"
         android:type="linear" />
 </shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,6 +18,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
+        android:background="@color/colorBackGround"
         android:fitsSystemWindows="true"
         android:theme="@style/MainDrawerTheme"
         app:headerLayout="@layout/nav_header_main"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#ffffff</color>
+    <color name="colorPrimary">#cac3b1</color>
     <color name="colorAccent">#268ad2</color>
     <color name="colorBackGround">#fdf6e3</color>
     <color name="colorBackGroundVariant">#eee8d5</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorPrimary">#ffffff</color>
-    <color name="colorPrimaryDark">#cac3b1</color>
     <color name="colorAccent">#268ad2</color>
     <color name="colorBackGround">#fdf6e3</color>
     <color name="colorBackGroundVariant">#eee8d5</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,6 +31,7 @@
 
     <style name="NyanNyanDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="android:colorAccent">@color/colorAccent</item>
+        <item name="android:background">@color/colorBackGround</item>
     </style>
 
     <style name="InputViewTheme" parent="Theme.AppCompat.Light.NoActionBar">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -11,6 +11,7 @@
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
     </style>
 
     <style name="NekogoTweetButton" parent="@android:style/Widget.Button">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorPrimaryDark">@color/colorPrimary</item>
         <item name="titleTextColor">@color/onPrimary</item>
         <item name="colorControlNormal">@color/onPrimary</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,6 +2,7 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowBackground">@color/colorBackGround</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimary</item>
         <item name="titleTextColor">@color/onPrimary</item>


### PR DESCRIPTION
## 概要

Pixel 4を見ていたら、ステータスバーとアプリバーの色を統一させたくなった。
統一させてみたところ、API level 23未満の端末においてはステータスバーの文字色を白から動かせなさそうだったので、従来のステータスバーの色をアプリバーに反映させることとした。

## 変更内容詳細

変更前|変更後
---|---
Pixel 4 API 30<br><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833199-3ded2a80-58da-11eb-877b-2757801ac89b.png"><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833203-42b1de80-58da-11eb-9873-0debc387e25f.png">|Pixel 4 API 30<br><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104832982-ec906b80-58d8-11eb-859d-211f269f3cbe.png"><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104832986-f6b26a00-58d8-11eb-91b1-07387ff1cb45.png">
Nexus 5X API 28<br><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833171-0bdbc880-58da-11eb-8a9b-b68274d4be96.png"><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833175-11391300-58da-11eb-9cca-302156223519.png">|Nexus 5X API 28<br><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833031-324d3400-58d9-11eb-98ff-caa4299f9d7d.png"><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833035-37aa7e80-58d9-11eb-962e-8d16a3d32688.png">
Nexus 5 API 22<br><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833138-d636df80-58d9-11eb-80f4-b3fc433fe604.png"><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833140-dc2cc080-58d9-11eb-8a8f-12bc346bd310.png">|Nexus 5 API 22<br><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833089-7dffdd80-58d9-11eb-99e0-8268286bd3e2.png"><img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833098-86f0af00-58d9-11eb-959d-4d88225ffdfc.png">

## 参考

下記が大変参考になった。

### ヘッダー全般

https://qiita.com/couzie/items/b00764b694ca299d93cb

### ステータスバーの色

https://stackoverflow.com/questions/38382283/change-status-bar-text-color-when-primarydark-is-white

### ダイアログ

https://stackoverflow.com/questions/18346920/change-the-background-color-of-a-pop-up-dialog

### 起動時の色

https://stackoverflow.com/questions/14462226/white-background-during-app-launch

## TODO

API level 22以下をフォローしなくなったらステータスバー白文字を気にしなくて良くなるので、メインテーマを白系に寄せても良さそう。