### PR TITLE
API level 22の端末において、ログイン後にメイン画面に戻れない不具合を修正

### DIFF
--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInFragment.kt
@@ -32,7 +32,7 @@ class SignInFragment : Fragment() {
 
         viewModel.signInEvent.observe(viewLifecycleOwner, Observer {
             (activity as? MainActivity)?.updateTweetList()
-            findNavController().popBackStack()
+            findNavController().navigate(R.id.action_singInFragment_to_mainFragment)
         })
         viewModel.executeSignIn(
             oauthVerifier = this.args.oauthVerifier,


### PR DESCRIPTION
## 概要

戻り先を指定したら、API level 22の端末でもちゃんと戻るようになった。API level 30の端末でも、戻る周りの挙動は特に変わっていない。

## 備考

Backstackがなくなってしまうのが原因のようだが、これはImplicit/Explicit Deep Link の違いのと思われる。
文献はなかったが、もしかしてAPI level 22ではディープリンクによるNavigation内起動がImplicitになってしまってしまっているのだろうか。

https://qiita.com/oboenikui/items/81c099acf5c0cf5215ec#deep-link