### PR TITLE
ツイート一覧内画像をグレースケール化

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The funny Twitter client android app. Every tweet you post and see are converted
 ## Designs
 
 <p align="center">
-	<img width="180 alt="image" src="https://user-images.githubusercontent.com/38374045/104833389-a5f04080-58db-11eb-9601-02bf1d1e65ee.png">
+	<img width="180 alt="image" src="https://user-images.githubusercontent.com/38374045/104847929-f2606e00-5925-11eb-906a-e3866d19ffde.png">
 	<img width="180" alt="image" src="https://user-images.githubusercontent.com/38374045/104833404-c3bda580-58db-11eb-93e4-b8a6e6ace57f.png">
 </p>
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewHolder.kt
@@ -8,6 +8,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
 import coil.api.load
+import coil.transform.GrayscaleTransformation
 import coil.transform.RoundedCornersTransformation
 import com.ntetz.android.nyannyanengine_android.R
 import com.ntetz.android.nyannyanengine_android.databinding.MainCellBinding
@@ -34,6 +35,7 @@ class MainViewHolder(
             placeholder(R.mipmap.ic_launcher_foreground)
             crossfade(true)
             transformations(RoundedCornersTransformation(16f))
+            transformations(GrayscaleTransformation())
         }
         val userName = "@${item.user.screenName}"
         binding.screenName.text = userName


### PR DESCRIPTION
## 概要

#102 で暗めの色ベースにしたらツイートの画像が悪目立ちするようになってしまったので、色を抑えた

## 変更内容詳細

変更前|変更後
---|---
<img width="404" alt="image" src="https://user-images.githubusercontent.com/38374045/104848024-6c90f280-5926-11eb-8d88-f0815063b7a7.png">|<img width="404" alt="image" src="https://user-images.githubusercontent.com/38374045/104847965-28055700-5926-11eb-96b0-957f0ee503d5.png">

