### PR TITLE
Gradle 7.1系へのアップグレード

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,8 @@
         <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="/usr/local/Cellar/gradle/6.4.1/libexec" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,10 +148,6 @@ dependencies {
     implementation "com.google.dagger:hilt-android:${dagger_hilt_version}"
     kapt "com.google.dagger:hilt-android-compiler:${dagger_hilt_version}"
 
-    def dagger_hilt_view_model_version = "1.0.0-alpha02"
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:${dagger_hilt_view_model_version}"
-    kapt "androidx.hilt:hilt-compiler:${dagger_hilt_view_model_version}"
-
     def retrofit_version = "2.9.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofit_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.google.firebase:firebase-appdistribution-gradle:2.0.1"
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:2.1.1'
     }
 }
 
@@ -144,7 +144,7 @@ dependencies {
     implementation "com.google.firebase:firebase-crashlytics-ktx"
     implementation "com.google.firebase:firebase-firestore:22.0.1"
 
-    def dagger_hilt_version = "2.31-alpha"
+    def dagger_hilt_version = "2.41"
     implementation "com.google.dagger:hilt-android:${dagger_hilt_version}"
     kapt "com.google.dagger:hilt-android-compiler:${dagger_hilt_version}"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/main/MainViewModel.kt
@@ -1,7 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.main
 
 import android.content.Context
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -19,12 +18,15 @@ import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_tran
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.lang.ref.WeakReference
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
-class MainViewModel @ViewModelInject constructor(
+@HiltViewModel
+class MainViewModel @Inject constructor(
     private val accountUsecase: IAccountUsecase,
     private val tweetsUsecase: ITweetsUsecase,
     private val userActionUsecase: IUserActionUsecase,

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/post_nekogo/PostNekogoViewModel.kt
@@ -1,7 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.post_nekogo
 
 import android.content.Context
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -12,11 +11,14 @@ import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_tran
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.ITweetsUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.lang.ref.WeakReference
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 
-class PostNekogoViewModel @ViewModelInject constructor(
+@HiltViewModel
+class PostNekogoViewModel @Inject constructor(
     private val accountUsecase: IAccountUsecase,
     private val tweetsUsecase: ITweetsUsecase,
     private val userActionUsecase: IUserActionUsecase,

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/setting/hashtag/HashtagSettingViewModel.kt
@@ -1,7 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.setting.hashtag
 
 import android.content.Context
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -10,11 +9,14 @@ import com.ntetz.android.nyannyanengine_android.model.entity.usecase.hashtag.Def
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IHashtagUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.lang.ref.WeakReference
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 
-class HashtagSettingViewModel @ViewModelInject constructor(
+@HiltViewModel
+class HashtagSettingViewModel @Inject constructor(
     private val hashtagUsecase: IHashtagUsecase,
     private val userActionUsecase: IUserActionUsecase,
     @ApplicationContext context: Context

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_in/SignInViewModel.kt
@@ -1,7 +1,6 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_in
 
 import android.content.Context
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -10,11 +9,14 @@ import com.ntetz.android.nyannyanengine_android.model.entity.usecase.account.Sig
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.lang.ref.WeakReference
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 
-class SignInViewModel @ViewModelInject constructor(
+@HiltViewModel
+class SignInViewModel @Inject constructor(
     private val accountUsecase: IAccountUsecase,
     private val userActionUsecase: IUserActionUsecase,
     @ApplicationContext context: Context

--- a/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModel.kt
+++ b/app/src/main/java/com/ntetz/android/nyannyanengine_android/ui/sign_out/SignOutViewModel.kt
@@ -1,6 +1,5 @@
 package com.ntetz.android.nyannyanengine_android.ui.sign_out
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -9,9 +8,12 @@ import com.ntetz.android.nyannyanengine_android.model.entity.dao.retrofit.Access
 import com.ntetz.android.nyannyanengine_android.model.entity.usecase.screen_transition.UserAction
 import com.ntetz.android.nyannyanengine_android.model.usecase.IAccountUsecase
 import com.ntetz.android.nyannyanengine_android.model.usecase.IUserActionUsecase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 
-class SignOutViewModel @ViewModelInject constructor(
+@HiltViewModel
+class SignOutViewModel @Inject constructor(
     private val accountUsecase: IAccountUsecase,
     private val userActionUsecase: IUserActionUsecase
 ) : ViewModel() {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,12 @@ stages:
     - script: |
         cp -pi app/gradle_secret_sample.properties app/gradle_secret.properties
       displayName: 'appモジュールビルド用ダミー設定の設置'
+    - task: JavaToolInstaller@0
+      inputs:
+        versionSpec: '11'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
+      displayName: 'ビルド用Javaバージョン指定'
     - task: Gradle@2
       displayName: '全環境に対してのbuild, lint, test'
       inputs:
@@ -113,6 +119,12 @@ stages:
     - script: |
         sudo ln -s $(privateBundle.secureFilePath) app/src/main/cpp/secure-config-master-lib.cpp
       displayName: '秘匿系設定ファイルの参照をプロジェクト内部に設置'
+    - task: JavaToolInstaller@0
+      inputs:
+        versionSpec: '11'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
+      displayName: 'ビルド用Javaバージョン指定'
     - task: Gradle@2
       displayName: 'dev環境Releaseビルドを配布'
       inputs:

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ buildscript {
         
     }
     dependencies {
-        def dagger_hilt_version = "2.31-alpha"
+        def dagger_hilt_version = "2.41"
         classpath "com.google.dagger:hilt-android-gradle-plugin:${dagger_hilt_version}"
 
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.2"
-        classpath "com.google.gms:google-services:4.3.4"
-        classpath "com.google.firebase:firebase-crashlytics-gradle:2.4.1"
-        classpath "com.android.tools.build:gradle:4.1.1"
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
## 概要

Android StudioのポップアップでGradleのバージョンアップをしたら？
と出てきたので対応。

<img width="446" alt="image" src="https://user-images.githubusercontent.com/38374045/156921206-3bb349e7-b843-45c4-9524-b8deefcb7014.png">

## 変更内容詳細

Gradleのバージョンアップと、それにより動かなくなったHiltの記述のバージョンアップをおこなっている。

## 参考

### Android StudioのPreferenceの中のjavaバージョン

https://stackoverflow.com/questions/30631286/how-to-specify-the-jdk-version-in-android-studio

### Hiltの更新

https://dagger.dev/hilt/gradle-setup
https://mvnrepository.com/artifact/com.google.dagger/hilt-android-gradle-plugin
https://stackoverflow.com/questions/67256565/defaultactivityviewmodelfactory-not-found
https://dagger.dev/hilt/view-model.html
https://stackoverflow.com/questions/66185820/dagger-hilt-assisted-and-viewmodelinject-is-deprecated-in-dagger-hilt-view